### PR TITLE
Change login popup color from red to WordPress Blue

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/common.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/common.css
@@ -35,7 +35,7 @@
 	z-index: 10;
 	margin: 2.4em;
 	padding: 1.8em;
-	background-color: #c62828;
+	background-color: #0073aa;
 	border-radius: 0.25em;
 	margin-bottom: 2em;
 }

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/front-end.css
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/front-end.css
@@ -7,7 +7,7 @@
 	z-index: 10;
 	margin: 2.4em;
 	padding: 1.8em;
-	background-color: #c62828;
+	background-color: #0073aa;
 	border-radius: 0.25em;
 	margin-bottom: 2em;
 }


### PR DESCRIPTION
## Summary
- Changes the login popup background color from red (`#c62828`) to WordPress Blue (`#0073aa`) on application forms
- The red color felt alarming and could be mistaken for an error state — this is just an informational prompt to log in
- Updated in both `wcpt/css/applications/common.css` (event/WordCamp applications) and `wordcamp-forms-to-drafts/front-end.css` (speaker proposals, contact forms)

## Test plan
- [ ] Visit an event application page while logged out and verify the login popup has a blue background
- [ ] Visit a speaker proposal form while logged out and verify the same
- [ ] Verify text and links remain readable (white on blue)

Fixes https://github.com/WordPress/wordcamp.org/issues/1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)