### PR TITLE
Fix cookie banner translation by removing \r from string

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/privacy.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/privacy.php
@@ -58,7 +58,7 @@ function render_cookie_banner() {
 		'hide'               => 'button',
 		'consent-expiration' => 365,
 		'text'               => 'custom',
-		'customtext'         => __( "Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use. \r\nTo find out more, including how to control cookies, please see here:", 'wordcamporg' ) . ' ',
+		'customtext'         => __( "Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use.\nTo find out more, including how to control cookies, please see here:", 'wordcamporg' ) . ' ',
 		'color-scheme'       => 'default',
 		'policy-url'         => 'custom',
 		'custom-policy-url'  => trailingslashit( get_privacy_policy_url() ) . 'cookies/',


### PR DESCRIPTION
## Summary
- The cookie banner text on line 61 of `privacy.php` contained `\r\n` (CRLF) which prevents translation lookups from matching
- PO/MO files do not support `\r` in internationalized messages, so the translated string never matched the source string
- Removes the `\r` so the string uses just `\n`, allowing existing translations (e.g. Polish) to display correctly
- This was independently confirmed as the root cause in the issue comments, and the same bug exists upstream in Jetpack (reported as Automattic/jetpack#45364)
- Also removes a trailing space before the newline for consistency

## Test plan
- [ ] Visit a WordCamp site with a non-English locale (e.g. krakow.wordcamp.org) and verify the cookie banner text is translated
- [ ] Verify the cookie banner still renders correctly on English sites

Fixes https://github.com/WordPress/wordcamp.org/issues/1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)