### PR TITLE
Allow disabling Coming Soon on closed events, prevent enabling

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -52,6 +52,7 @@ require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
 require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments-network/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/wordcamp-coming-soon-page/tests/bootstrap.php';
 
 /*
  * This has to be the last plugin bootstrapper, because it includes the Core test bootstrapper, which would

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,6 +61,12 @@
 				./public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/
 			</directory>
 		</testsuite>
+
+		<testsuite name="WordCamp Coming Soon Page">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/
+			</directory>
+		</testsuite>
 	</testsuites>
 
 	<coverage cacheDirectory=".phpunit/coverage-cache">
@@ -69,7 +75,8 @@
 			<directory suffix=".php">./public_html/wp-content/plugins/camptix</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wc-post-types</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wcpt</directory>
-			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-organizer-reminders</directory>
+			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-coming-soon-page</directory>
+						<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-organizer-reminders</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-payments/</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-payments-network/</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-remote-css</directory>

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
@@ -206,21 +206,28 @@ class WCCSP_Customizer {
 	 * @return boolean           Status of the field validity.
 	 */
 	public function maybe_prevent_disable( $validity, $value ) {
-		// Short circuit when the value is on.
-		if ( 'on' === $value ) {
-			return $validity;
-		}
+		$status = $this->get_status();
 
 		// Short circuit when deputy is changing the value.
 		if ( current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 			return $validity;
 		}
 
-		// If WordCamp is not added to schedule, field is not valid.
-		if ( 'wcpt-scheduled' !== $this->get_status() ) {
-			return new WP_Error( 'wcpt-not-in-schedule', __( 'The Coming Soon page can not be turned off because WordCamp is not yet published in the schedule.' ) );
+		// Prevent enabling Coming Soon on closed events.
+		if ( 'on' === $value && 'wcpt-closed' === $status ) {
+			return new WP_Error( 'wcpt-closed', __( 'The Coming Soon page can not be enabled because this event is closed.', 'wordcamporg' ) );
 		}
 
-		return $validity;
+		// Allow toggling for scheduled or closed events.
+		if ( 'on' === $value ) {
+			return $validity;
+		}
+
+		// Allow disabling for scheduled or closed events.
+		if ( in_array( $status, array( 'wcpt-scheduled', 'wcpt-closed' ), true ) ) {
+			return $validity;
+		}
+
+		return new WP_Error( 'wcpt-not-in-schedule', __( 'The Coming Soon page can not be turned off because WordCamp is not yet published in the schedule.', 'wordcamporg' ) );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WordCamp\Coming_Soon_Page\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests.
+ */
+function manually_load_plugins() {
+	require_once dirname( __DIR__ ) . '/classes/wccsp-settings.php';
+	require_once dirname( __DIR__ ) . '/classes/wccsp-customizer.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-coming-soon-toggle.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-coming-soon-toggle.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace WordCamp\Coming_Soon_Page\Tests;
+
+use WCCSP_Customizer;
+use WP_Error;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group coming-soon-page
+ *
+ * @covers WCCSP_Customizer::maybe_prevent_disable
+ */
+class Test_Coming_Soon_Toggle extends WP_UnitTestCase {
+	/**
+	 * @var int
+	 */
+	protected static $admin_user_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $organizer_user_id;
+
+	/**
+	 * @var WCCSP_Customizer
+	 */
+	protected static $customizer;
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$admin_user_id = $factory->user->create( array(
+			'role' => 'administrator',
+		) );
+
+		self::$organizer_user_id = $factory->user->create( array(
+			'role' => 'editor',
+		) );
+
+		self::$customizer = new WCCSP_Customizer();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+
+		// Reset to a non-privileged user.
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Helper to create a mock customizer that returns the specified status from get_status().
+	 *
+	 * @param string|null $status The WordCamp post status.
+	 *
+	 * @return WCCSP_Customizer
+	 */
+	protected function get_customizer_with_status( $status ) {
+		$mock = $this->getMockBuilder( WCCSP_Customizer::class )
+			->onlyMethods( array( 'get_status' ) )
+			->getMock();
+
+		$mock->method( 'get_status' )->willReturn( $status );
+
+		return $mock;
+	}
+
+	/**
+	 * Grant the wrangler capability to all capability checks for the current user.
+	 *
+	 * @param bool[]   $allcaps All capabilities for the user.
+	 * @param string[] $caps    Required primitive capabilities.
+	 * @param array    $args    Arguments for the capability check.
+	 *
+	 * @return bool[]
+	 */
+	public function grant_wrangler_cap( $allcaps, $caps, $args ) {
+		$allcaps['wordcamp_wrangle_wordcamps'] = true;
+		return $allcaps;
+	}
+
+	/**
+	 * Test that an admin/wrangler can always toggle the coming-soon page regardless of status.
+	 */
+	public function test_wrangler_can_always_enable() {
+		wp_set_current_user( self::$admin_user_id );
+		add_filter( 'user_has_cap', array( $this, 'grant_wrangler_cap' ), 10, 3 );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-closed' );
+		$result     = $customizer->maybe_prevent_disable( true, 'on' );
+
+		remove_filter( 'user_has_cap', array( $this, 'grant_wrangler_cap' ), 10 );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that an admin/wrangler can always disable the coming-soon page regardless of status.
+	 */
+	public function test_wrangler_can_always_disable() {
+		wp_set_current_user( self::$admin_user_id );
+		add_filter( 'user_has_cap', array( $this, 'grant_wrangler_cap' ), 10, 3 );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-pre-planning' );
+		$result     = $customizer->maybe_prevent_disable( true, 'off' );
+
+		remove_filter( 'user_has_cap', array( $this, 'grant_wrangler_cap' ), 10 );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a non-admin cannot enable coming-soon on a closed event.
+	 */
+	public function test_organizer_cannot_enable_on_closed_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-closed' );
+		$result     = $customizer->maybe_prevent_disable( true, 'on' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'wcpt-closed', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a non-admin can enable coming-soon for a scheduled event.
+	 */
+	public function test_organizer_can_enable_on_scheduled_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-scheduled' );
+		$result     = $customizer->maybe_prevent_disable( true, 'on' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a non-admin can enable coming-soon for a pre-planning event.
+	 */
+	public function test_organizer_can_enable_on_pre_planning_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-pre-planning' );
+		$result     = $customizer->maybe_prevent_disable( true, 'on' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a non-admin can disable coming-soon when status is wcpt-scheduled.
+	 */
+	public function test_organizer_can_disable_on_scheduled_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-scheduled' );
+		$result     = $customizer->maybe_prevent_disable( true, 'off' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a non-admin can disable coming-soon when status is wcpt-closed.
+	 */
+	public function test_organizer_can_disable_on_closed_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-closed' );
+		$result     = $customizer->maybe_prevent_disable( true, 'off' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a non-admin cannot disable coming-soon when status is not scheduled or closed.
+	 */
+	public function test_organizer_cannot_disable_on_pre_planning_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-pre-planning' );
+		$result     = $customizer->maybe_prevent_disable( true, 'off' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'wcpt-not-in-schedule', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a non-admin cannot disable coming-soon when status is needs-vetting.
+	 */
+	public function test_organizer_cannot_disable_on_needs_vetting_event() {
+		wp_set_current_user( self::$organizer_user_id );
+
+		$customizer = $this->get_customizer_with_status( 'wcpt-needs-vetting' );
+		$result     = $customizer->maybe_prevent_disable( true, 'off' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'wcpt-not-in-schedule', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary
- Closed WordCamp events can now turn off the Coming Soon page (previously blocked because the validator only allowed `wcpt-scheduled` status)
- Explicitly prevents enabling Coming Soon on already-closed events, since that does not make sense
- Deputies can still toggle the setting regardless of status

Fixes https://github.com/WordPress/wordcamp.org/issues/1116

## Test plan
- [ ] Set a WordCamp to `wcpt-scheduled` status - verify Coming Soon can be toggled on/off
- [ ] Set a WordCamp to `wcpt-closed` status with Coming Soon ON - verify it can be turned OFF
- [ ] Set a WordCamp to `wcpt-closed` status with Coming Soon OFF - verify it CANNOT be turned ON
- [ ] Verify a deputy can toggle regardless of status
- [ ] Verify pre-scheduled statuses still block disabling Coming Soon

🤖 Generated with [Claude Code](https://claude.com/claude-code)