### PR TITLE
Require Actual Attendees before closing an event

### DIFF
--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-actual-attendees.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-actual-attendees.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace WordCamp\WCPT\Tests;
+use WP_UnitTestCase;
+use WordCamp_Admin;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for Actual Attendees field requirements
+ *
+ * @group wcpt
+ * @group wordcamp
+ */
+class Test_WordCamp_Actual_Attendees extends WP_UnitTestCase {
+
+	/**
+	 * @covers WordCamp_Admin::require_complete_meta_to_publish_wordcamp
+	 */
+	public function test_closing_without_actual_attendees_reverts_to_scheduled() {
+		$wordcamp_admin = new WordCamp_Admin();
+
+		$post_data = array(
+			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_status' => 'wcpt-closed',
+		);
+
+		$post_data_raw = array(
+			'ID' => 999999,
+		);
+
+		// Simulate admin form submission without Actual Attendees.
+		$_POST['action'] = 'editpost';
+
+		$result = $wordcamp_admin->require_complete_meta_to_publish_wordcamp( $post_data, $post_data_raw );
+
+		$this->assertSame( 'wcpt-scheduled', $result['post_status'], 'Status should revert to scheduled when Actual Attendees is missing' );
+
+		unset( $_POST['action'] );
+	}
+
+	/**
+	 * @covers WordCamp_Admin::require_complete_meta_to_publish_wordcamp
+	 */
+	public function test_closing_with_actual_attendees_allows_closed_status() {
+		$wordcamp_admin = new WordCamp_Admin();
+
+		$post_data = array(
+			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_status' => 'wcpt-closed',
+		);
+
+		$post_data_raw = array(
+			'ID' => 999999,
+		);
+
+		// Simulate admin form submission with Actual Attendees.
+		$_POST['action']              = 'editpost';
+		$_POST['wcpt_actual_attendees'] = '150';
+
+		$result = $wordcamp_admin->require_complete_meta_to_publish_wordcamp( $post_data, $post_data_raw );
+
+		$this->assertSame( 'wcpt-closed', $result['post_status'], 'Status should remain closed when Actual Attendees is provided' );
+
+		unset( $_POST['action'], $_POST['wcpt_actual_attendees'] );
+	}
+
+	/**
+	 * @covers WordCamp_Admin::require_complete_meta_to_publish_wordcamp
+	 */
+	public function test_cron_auto_close_is_not_blocked() {
+		$wordcamp_admin = new WordCamp_Admin();
+
+		$post_data = array(
+			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_status' => 'wcpt-closed',
+		);
+
+		$post_data_raw = array(
+			'ID' => 999999,
+		);
+
+		// No $_POST['action'] set - simulates cron context.
+
+		$result = $wordcamp_admin->require_complete_meta_to_publish_wordcamp( $post_data, $post_data_raw );
+
+		$this->assertSame( 'wcpt-closed', $result['post_status'], 'Cron auto-close should not be blocked by the validation' );
+	}
+
+	/**
+	 * @covers WordCamp_Admin::meta_keys
+	 */
+	public function test_actual_attendees_visible_when_scheduled() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_title'  => 'Test WordCamp Scheduled',
+				'post_status' => 'wcpt-needs-vetting',
+			)
+		);
+
+		// Directly update status to avoid transition hooks.
+		global $wpdb;
+		$wpdb->update( $wpdb->posts, array( 'post_status' => 'wcpt-scheduled' ), array( 'ID' => $post_id ) );
+		clean_post_cache( $post_id );
+
+		// Set up the global post so get_post() / get_post_status() work.
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		$keys = WordCamp_Admin::meta_keys( 'wordcamp' );
+
+		$this->assertArrayHasKey( 'Actual Attendees', $keys, 'Actual Attendees should be visible when status is wcpt-scheduled' );
+
+		wp_reset_postdata();
+	}
+
+	/**
+	 * @covers WordCamp_Admin::meta_keys
+	 */
+	public function test_actual_attendees_hidden_before_scheduled() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_title'  => 'Test WordCamp Pre-Planning',
+				'post_status' => 'wcpt-needs-vetting',
+			)
+		);
+
+		// Set up the global post so get_post() / get_post_status() work.
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		$keys = WordCamp_Admin::meta_keys( 'wordcamp' );
+
+		$this->assertArrayNotHasKey( 'Actual Attendees', $keys, 'Actual Attendees should be hidden before wcpt-scheduled status' );
+
+		wp_reset_postdata();
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-actual-attendees.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-actual-attendees.php
@@ -106,6 +106,7 @@ class Test_WordCamp_Actual_Attendees extends WP_UnitTestCase {
 
 		// Set up the global post so get_post() / get_post_status() work.
 		global $post;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional for test setup.
 		$post = get_post( $post_id );
 		setup_postdata( $post );
 
@@ -130,6 +131,7 @@ class Test_WordCamp_Actual_Attendees extends WP_UnitTestCase {
 
 		// Set up the global post so get_post() / get_post_status() work.
 		global $post;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional for test setup.
 		$post = get_post( $post_id );
 		setup_postdata( $post );
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -491,11 +491,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					}
 
 					/*
-					 * The "Actual Attendees" field is only able to be set after the event is concluded.
+					 * The "Actual Attendees" field is shown once the event is scheduled or closed,
+					 * and is required before closing the event.
 					 *
 					 * get_post() allows this to target the editor, allowing for report export.
 					 */
-					if ( get_post() && get_post_status() !== 'wcpt-closed' ) {
+					if ( get_post() && ! in_array( get_post_status(), array( 'wcpt-scheduled', 'wcpt-closed' ), true ) ) {
 						unset( $retval['Actual Attendees'] );
 					}
 
@@ -537,11 +538,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					}
 
 					/*
-					 * The "Actual Attendees" field is only able to be set after the event is concluded.
+					 * The "Actual Attendees" field is shown once the event is scheduled or closed,
+					 * and is required before closing the event.
 					 *
 					 * get_post() allows this to target the editor, allowing for report export.
 					 */
-					if ( get_post() && get_post_status() !== 'wcpt-closed' ) {
+					if ( get_post() && ! in_array( get_post_status(), array( 'wcpt-scheduled', 'wcpt-closed' ), true ) ) {
 						unset( $retval['Actual Attendees'] );
 					}
 
@@ -1114,6 +1116,18 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				}
 			}
 
+			// Closed - require Actual Attendees (only for admin form submissions, not cron auto-close).
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce check would have done in `metabox_save`.
+			if ( 'wcpt-closed' === $post_data['post_status'] && isset( $post_data_raw['ID'] ) && ! empty( $_POST['action'] ) && 'editpost' === $_POST['action'] ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce check would have done in `metabox_save`.
+				$actual_attendees = $_POST[ wcpt_key_to_str( 'Actual Attendees', 'wcpt_' ) ] ?? '';
+
+				if ( empty( $actual_attendees ) && '0' !== $actual_attendees ) {
+					$post_data['post_status']     = 'wcpt-scheduled';
+					$this->active_admin_notices[] = 5;
+				}
+			}
+
 			return $post_data;
 		}
 
@@ -1292,6 +1306,11 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						__( 'The %s could not be geocoded, which prevents the camp from showing up in the Events Widget. Please tweak the address so that Google Maps can parse it.', 'wordcamporg' ),
 						self::get_address_key( $post->ID )
 					),
+				),
+
+				5 => array(
+					'type'   => 'error',
+					'notice' => __( 'This WordCamp cannot be closed until the Actual Attendees field is filled in.', 'wordcamporg' ),
 				),
 			);
 


### PR DESCRIPTION
## Summary
- Shows the **Actual Attendees** field when event status is `wcpt-scheduled` (previously only shown after `wcpt-closed`), so supporters can fill it in before closing
- Adds validation to prevent manual transition to `wcpt-closed` without filling in the Actual Attendees count
- Cron auto-close (`close_wordcamps_after_event`) is not affected - it bypasses this validation since it is not an admin form submission and auto-fills the field from CampTix data
- Adds admin error notice when the validation blocks closing

## Changes
- `wordcamp-admin.php`: Changed `Actual Attendees` visibility condition from `wcpt-closed` only to `wcpt-scheduled` or `wcpt-closed`. Added closed-status validation in `require_complete_meta_to_publish_wordcamp()`. Added admin notice #5.
- New test file `test-wordcamp-actual-attendees.php` with 5 tests covering: validation blocks close without attendees, allows close with attendees, does not block cron, field visibility at scheduled/pre-scheduled statuses.

## Test plan
- [ ] Set event to `wcpt-scheduled` status - verify Actual Attendees field appears
- [ ] Try to close event without filling Actual Attendees - verify error notice and status reverts to scheduled
- [ ] Fill in Actual Attendees and close - verify it works
- [ ] Verify cron auto-close still works (no `$_POST` context)
- [ ] All 5 new PHPUnit tests pass

Closes WordPress/wordcamp.org#1603

Generated with [Claude Code](https://claude.com/claude-code)