### PR TITLE
Allow featured images on Speakers/Organizers for block themes

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1196,6 +1196,13 @@ class WordCamp_Post_Types_Plugin {
 			return $value;
 		}
 
+		// Block themes handle featured images via templates, so organizers can
+		// control whether the image appears. The avatar is also not auto-injected
+		// on block themes, so there is no duplication issue.
+		if ( wp_is_block_theme() ) {
+			return $value;
+		}
+
 		$post_types = array( 'wcb_speaker', 'wcb_organizer' );
 		if ( in_array( get_post_type( $object_id ), $post_types, true ) ) {
 			return false;


### PR DESCRIPTION
## Summary
- Fixes featured images not being saved/displayed on Speaker and Organizer posts when using a block theme
- The `hide_featured_image_on_people` filter was hiding the `_thumbnail_id` meta to prevent duplicate images on classic themes (where the avatar is auto-injected into content AND the theme template shows the featured image)
- Block themes do not have this duplication issue because the avatar is not auto-injected and organizers control featured image display via templates

## Changes
- `wc-post-types.php`: Added `wp_is_block_theme()` check to `hide_featured_image_on_people()` to bypass the filter on block themes

## Context
Per discussion in #1343, @ryelle identified that `hide_featured_image_on_people` was the root cause and recommended this approach. @dd32 also suggested potentially using `has_post_thumbnail` filter instead, but the `wp_is_block_theme()` check is the simplest safe fix.

## Test plan
- [ ] On a block theme site: edit a Speaker, set a featured image, save, reload - verify image persists
- [ ] On a block theme site: verify the Featured Image block works for Speakers/Organizers
- [ ] On a classic theme site: verify the old behavior (hiding featured images to prevent duplication) still works

Closes WordPress/wordcamp.org#1343

Generated with [Claude Code](https://claude.com/claude-code)