### PR TITLE
Use event name in budget approval email subject

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -115,20 +115,24 @@ class WordCamp_Budget_Tool {
 			// Submit for Approval.
 			$budget['prelim'] = $data;
 			$budget['status'] = 'pending';
-			$domain           = parse_url( home_url(), PHP_URL_HOST );
+			$event_name       = get_wordcamp_name();
 			$link             = esc_url_raw( add_query_arg( 'page', 'wordcamp-budget', admin_url( 'admin.php' ) ) );
+			$sender           = get_wordcamp_post()->meta['E-mail Address'][0] ?? '';
+			$headers          = $sender ? array( 'From: ' . $sender ) : array();
 
-			$content = "A budget approval request has been submitted for {$domain} by {$user->user_login}:\n\n{$link}\n\nYours, Mr. Budget Tool";
-			wp_mail( 'support@wordcamp.org', 'Budget Approval Requested: ' . $domain, $content );
+			$content = "A budget approval request has been submitted for {$event_name} by {$user->user_login}:\n\n{$link}\n\nYours, Mr. Budget Tool";
+			wp_mail( 'support@wordcamp.org', 'Budget Approval Requested: ' . $event_name, $content, $headers );
 
 		} elseif ( 'draft' === $budget['status'] && ! empty( $_POST['wcb-budget-request-review'] ) ) {
 			// Save draft and request review.
 			$budget['prelim'] = $data;
-			$domain           = parse_url( home_url(), PHP_URL_HOST );
+			$event_name       = get_wordcamp_name();
 			$link             = esc_url_raw( add_query_arg( 'page', 'wordcamp-budget', admin_url( 'admin.php' ) ) );
+			$sender           = get_wordcamp_post()->meta['E-mail Address'][0] ?? '';
+			$headers          = $sender ? array( 'From: ' . $sender ) : array();
 
-			$content = "A budget review has been requested for {$domain} by {$user->user_login}:\n\n{$link}\n\nYours, Mr. Budget Tool";
-			wp_mail( 'support@wordcamp.org', 'Budget Review Requested: ' . $domain, $content );
+			$content = "A budget review has been requested for {$event_name} by {$user->user_login}:\n\n{$link}\n\nYours, Mr. Budget Tool";
+			wp_mail( 'support@wordcamp.org', 'Budget Review Requested: ' . $event_name, $content, $headers );
 
 		} elseif ( 'pending' === $budget['status'] && current_user_can( 'wcb_approve_budget' ) ) {
 			if ( ! empty( $_POST['wcb-budget-reject'] ) ) {


### PR DESCRIPTION
## Summary
- Replaces `parse_url( home_url(), PHP_URL_HOST )` with `get_wordcamp_name()` in budget email subject and body
- For NextGen events on `events.wordpress.org`, the domain is shared across all events, making subjects like "Budget Approval Requested: events.wordpress.org" indistinguishable
- Now sends descriptive subjects like "Budget Approval Requested: WordCamp Narnia 2025"
- Also sets the From header using the event email address (`get_wordcamp_post()->meta['E-mail Address']`) when available

## Changes
- `budget-tool.php` lines 114-131: Both "Submit for Approval" and "Request Review" email paths updated

## Test plan
- [ ] On a NextGen event site, submit a budget for approval and verify the email subject contains the event name
- [ ] On a classic WordCamp site, verify the email subject still shows the event name correctly
- [ ] Verify the From header is set when the event has an email address configured

Fixes https://github.com/WordPress/wordcamp.org/issues/1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)