### PR TITLE
Use event start date for speaker badge activity timestamp

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -385,10 +385,13 @@ class WordCamp_Participation_Notifier {
 			? (int) $wordcamp->meta['Start Date (YYYY-mm-dd)'][0]
 			: strtotime( $post->post_date_gmt );
 
+		// Cap at current time so future events don't get a future activity timestamp.
+		$timestamp = min( $event_start, time() );
+
 		$activity = array(
 			'action'        => 'wporg_handle_activity',
 			'source'        => 'wordcamp',
-			'timestamp'     => $event_start,
+			'timestamp'     => $timestamp,
 			'user'          => $user_id,
 			'wordcamp_id'   => get_current_blog_id(),
 			'wordcamp_name' => get_wordcamp_name(),

--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -381,10 +381,14 @@ class WordCamp_Participation_Notifier {
 			return false;
 		}
 
+		$event_start = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] )
+			? (int) $wordcamp->meta['Start Date (YYYY-mm-dd)'][0]
+			: strtotime( $post->post_date_gmt );
+
 		$activity = array(
 			'action'        => 'wporg_handle_activity',
 			'source'        => 'wordcamp',
-			'timestamp'     => strtotime( $post->post_modified_gmt ),
+			'timestamp'     => $event_start,
 			'user'          => $user_id,
 			'wordcamp_id'   => get_current_blog_id(),
 			'wordcamp_name' => get_wordcamp_name(),


### PR DESCRIPTION
## Summary
- Changes the activity timestamp in `get_post_activity_payload()` from `post_modified_gmt` to the WordCamp start date
- Falls back to `post_date_gmt` (published date) if no event start date is available
- Previously, when a speaker badge was awarded months after the event (e.g. when the WordPress.org username was finally added), the activity showed the current date rather than when the event happened

## Changes
- `wordcamp-participation-notifier.php`: Replace `strtotime($post->post_modified_gmt)` with WordCamp start date, falling back to post published date

## Test plan
- [ ] On a sandbox, add a WordPress.org username to a speaker post for a past WordCamp
- [ ] Verify the profile activity log shows the event date, not the current date
- [ ] Verify that for current/recent events, the behavior is unchanged (event start date is used)

Fixes https://github.com/WordPress/wordcamp.org/issues/1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)