### PR TITLE
Use locale-aware collation for attendee list sorting

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -298,7 +298,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 					// Use a Unicode 5.2 collation for locale-aware sorting when ordering by title.
 					$collate_filter = null;
 					if ( 'title' === $attr['orderby'] ) {
-						$collate_filter = function( $orderby ) {
+						$collate_filter = function ( $orderby ) {
 							return str_replace(
 								'.post_title ',
 								'.post_title COLLATE utf8mb4_unicode_520_ci ',

--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -286,14 +286,33 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 								'paged'          => $paged,
 								'order'          => $attr['order'],
 								'orderby'        => $attr['orderby'],
-								'fields'         => 'ids', // ! no post objects
-								'cache_results'  => false,
+								'fields'           => 'ids', // ! no post objects
+								'cache_results'    => false,
+								'suppress_filters' => false, // Required for posts_orderby filter.
 							),
 							$query_args
 						),
 						$attr
 					);
-					$attendees     = get_posts( $attendee_args );
+
+					// Use a Unicode 5.2 collation for locale-aware sorting when ordering by title.
+					$collate_filter = null;
+					if ( 'title' === $attr['orderby'] ) {
+						$collate_filter = function( $orderby ) {
+							return str_replace(
+								'.post_title ',
+								'.post_title COLLATE utf8mb4_unicode_520_ci ',
+								$orderby
+							);
+						};
+						add_filter( 'posts_orderby', $collate_filter );
+					}
+
+					$attendees = get_posts( $attendee_args );
+
+					if ( $collate_filter ) {
+						remove_filter( 'posts_orderby', $collate_filter );
+					}
 
 					if ( ! is_array( $attendees ) || count( $attendees ) < 1 ) {
 						break; // life saver!


### PR DESCRIPTION
## Summary
- Adds `utf8mb4_unicode_520_ci` collation to the ORDER BY clause when the `[camptix_attendees]` shortcode sorts by title
- The default `utf8mb4_unicode_ci` collation uses Unicode 4.0 sorting rules, which incorrectly sorts characters like Polish Ł (after Z instead of with L)
- Uses `posts_orderby` filter with `suppress_filters => false` as discussed in the issue comments by @dd32 and @pkevan

## Changes
- `camptix/addons/shortcodes.php`: Added `suppress_filters => false` to `get_posts()` args, and a temporary `posts_orderby` filter that adds the COLLATE clause when sorting by title

## Implementation details
- The filter is added just before the query and removed immediately after, so it only affects this specific query
- The collation override only applies when `orderby` is `title` (the default)
- Per @dd32: `SELECT post_title FROM wc_posts WHERE post_type = 'tix_attendee' ORDER BY post_title COLLATE 'utf8mb4_unicode_520_ci' ASC` produces correct sorting

## Test plan
- [x] Existing CampTix tests pass (63 tests, 80 assertions)
- [ ] Verify Polish characters (Ł, Ś, Ź, etc.) sort correctly on a site with Polish attendee names
- [ ] Verify sorting still works correctly for ASCII-only attendee names

Fixes https://github.com/WordPress/wordcamp.org/issues/1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)