### PR TITLE
Restrict bulk buy max to coupon target ticket only

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5358,10 +5358,6 @@ class CampTix_Plugin {
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
 				$coupon->tix_bypass_max_tickets_per_order = (int) get_post_meta( $coupon->ID, 'tix_bypass_max_tickets_per_order', true );
 				$this->coupon = $coupon;
-
-				if ( $coupon->tix_bypass_max_tickets_per_order ) {
-					$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
-				}
 			} else {
 				$this->error_flags['invalid_coupon'] = true;
 			}
@@ -5747,11 +5743,12 @@ class CampTix_Plugin {
 
 							// Recount selects, change price.
 							if ( $ticket->tix_coupon_applied ) {
+								$ticket_max = $max_tickets_per_order;
 								if ( $this->coupon->tix_bypass_max_tickets_per_order ) {
-									$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
+									$ticket_max = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
 								}
 
-								$max = min( $this->coupon->tix_coupon_remaining, $ticket->tix_remaining, $max_tickets_per_order );
+								$max = min( $this->coupon->tix_coupon_remaining, $ticket->tix_remaining, $ticket_max );
 
 								if ( $selected > $this->coupon->tix_coupon_remaining )
 									$selected = $this->coupon->tix_coupon_remaining;
@@ -7589,10 +7586,6 @@ class CampTix_Plugin {
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
 				$coupon->tix_bypass_max_tickets_per_order = (int) get_post_meta( $coupon->ID, 'tix_bypass_max_tickets_per_order', true );
-
-				if ( $coupon->tix_bypass_max_tickets_per_order ) {
-					$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
-				}
 			} else {
 				$order['coupon'] = null;
 				$coupon = null;
@@ -7668,8 +7661,13 @@ class CampTix_Plugin {
 				$this->error_flag( 'tickets_excess' );
 			}
 
-			if ( $item['quantity'] > $max_tickets_per_order ) {
-				$item['quantity'] = min( $max_tickets_per_order, $ticket->tix_remaining );
+			$item_max = $max_tickets_per_order;
+			if ( $ticket->tix_coupon_applied && $coupon && $coupon->tix_bypass_max_tickets_per_order ) {
+				$item_max = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
+			}
+
+			if ( $item['quantity'] > $item_max ) {
+				$item['quantity'] = min( $item_max, $ticket->tix_remaining );
 				$this->error_flag( 'tickets_excess' );
 			}
 


### PR DESCRIPTION
## Summary
- The `tix_bypass_max_tickets_per_order` coupon option was globally increasing the max tickets per order for ALL ticket types, not just the tickets the coupon targets
- Now the increased max is only applied to tickets where the coupon is actually applied (`tix_coupon_applied === true`)
- This follows up on PR #990 which introduced the bulk buy feature

## Changes
Three locations in `camptix.php` were fixed:

1. **Ticket selection form initialization** (~line 5360): Removed the global `$max_tickets_per_order` bump when coupon is loaded
2. **Ticket selection form rendering** (~line 5746): Changed to use a local `$ticket_max` variable instead of mutating the shared `$max_tickets_per_order`
3. **Order verification** (~line 7664): Added per-ticket check using `$item_max` that only bumps the max for coupon-applied tickets

## Test plan
- [x] Existing CampTix tests pass (63 tests, 80 assertions)
- [ ] Create a coupon that applies to Ticket A only, with bulk buy enabled
- [ ] Verify Ticket A shows the increased quantity dropdown (3x)
- [ ] Verify Ticket B (not targeted by coupon) still shows the normal max quantity
- [ ] Verify order validation enforces the correct limits per ticket type

Fixes https://github.com/WordPress/wordcamp.org/issues/1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)