### PR TITLE
Skip cancelled events in city redirect and latest site hints

### DIFF
--- a/phpunit-database-testcase.php
+++ b/phpunit-database-testcase.php
@@ -24,6 +24,8 @@ class Database_TestCase extends WP_UnitTestCase {
 	protected static $yearless_site_id;
 	protected static $slash_year_with_yearless_site_id;
 	protected static $events_rome_training_site_id;
+	protected static $year_dot_2020_cancelled_site_id;
+	protected static $slash_year_2021_cancelled_site_id;
 
 	/**
 	 * Create sites we'll need for the tests.
@@ -120,9 +122,41 @@ class Database_TestCase extends WP_UnitTestCase {
 			'network_id' => EVENTS_NETWORK_ID,
 		) );
 
+		// Cancelled sites: these are the "newest" but should be skipped due to cancelled status.
+		self::$year_dot_2020_cancelled_site_id = $factory->blog->create( array(
+			'domain'     => '2020.seattle.wordcamp.test',
+			'path'       => '/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
+		self::$slash_year_2021_cancelled_site_id = $factory->blog->create( array(
+			'domain'     => 'vancouver.wordcamp.test',
+			'path'       => '/2021/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
 		// Simulate renamed sites by adding old_home_url blogmeta.
 		add_site_meta( self::$slash_year_2020_site_id, 'old_home_url', 'https://vancouver.wordcamp.test/2019/' );
 		add_site_meta( self::$events_rome_training_site_id, 'old_home_url', 'https://events.wordpress.test/rome/2023/training/' );
+
+		// Create WordCamp posts on the central/root blog with 'wcpt-cancelled' status for the cancelled sites.
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+
+		$cancelled_seattle_post_id = wp_insert_post( array(
+			'post_type'   => 'wordcamp',
+			'post_status' => 'wcpt-cancelled',
+			'post_title'  => 'WordCamp Seattle 2020 (Cancelled)',
+		) );
+		update_post_meta( $cancelled_seattle_post_id, '_site_id', self::$year_dot_2020_cancelled_site_id );
+
+		$cancelled_vancouver_post_id = wp_insert_post( array(
+			'post_type'   => 'wordcamp',
+			'post_status' => 'wcpt-cancelled',
+			'post_title'  => 'WordCamp Vancouver 2021 (Cancelled)',
+		) );
+		update_post_meta( $cancelled_vancouver_post_id, '_site_id', self::$slash_year_2021_cancelled_site_id );
+
+		restore_current_blog();
 	}
 
 	/**
@@ -140,6 +174,8 @@ class Database_TestCase extends WP_UnitTestCase {
 		wp_delete_site( self::$slash_year_2018_dev_site_id );
 		wp_delete_site( self::$slash_year_2020_site_id );
 		wp_delete_site( self::$events_rome_training_site_id );
+		wp_delete_site( self::$year_dot_2020_cancelled_site_id );
+		wp_delete_site( self::$slash_year_2021_cancelled_site_id );
 
 		foreach ( [ WORDCAMP_NETWORK_ID, EVENTS_NETWORK_ID ] as $network_id ) {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE site_id = %d", $network_id ) );

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -168,6 +168,11 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		return false;
 	}
 
+	$central_prefix = $wpdb->get_blog_prefix( WORDCAMP_ROOT_BLOG_ID );
+	$cancelled_filter = "LEFT JOIN {$central_prefix}postmeta pm ON pm.meta_key = '_site_id' AND pm.meta_value = b.blog_id
+		LEFT JOIN {$central_prefix}posts p ON p.ID = pm.post_id AND p.post_type = 'wordcamp'";
+	$cancelled_where = "AND ( p.post_status IS NULL OR p.post_status != 'wcpt-cancelled' )";
+
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		// Remove the year prefix.
 		$city_domain = substr(
@@ -176,22 +181,26 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		);
 
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
+			SELECT b.`domain`, b.`path`
+			FROM `$wpdb->blogs` b
+			{$cancelled_filter}
 			WHERE
-				`domain` LIKE %s AND
-				SUBSTR( domain, 1, 4 ) REGEXP '^-?[0-9]+$' -- exclude secondary language domains like 2013-fr.ottawa.wordcamp.org
-			ORDER BY `domain` DESC
+				b.`domain` LIKE %s AND
+				SUBSTR( b.domain, 1, 4 ) REGEXP '^-?[0-9]+$' -- exclude secondary language domains like 2013-fr.ottawa.wordcamp.org
+				{$cancelled_where}
+			ORDER BY b.`domain` DESC
 			LIMIT 1",
 			'%.' . $city_domain
 		);
 
 	} elseif ( preg_match( PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
-			WHERE `domain` = %s
-			ORDER BY `domain`, `path` DESC
+			SELECT b.`domain`, b.`path`
+			FROM `$wpdb->blogs` b
+			{$cancelled_filter}
+			WHERE b.`domain` = %s
+				{$cancelled_where}
+			ORDER BY b.`domain`, b.`path` DESC
 			LIMIT 1",
 			$current_domain
 		);
@@ -202,12 +211,14 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		$latest_path = "/$city/%%/$type/";
 
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
+			SELECT b.`domain`, b.`path`
+			FROM `$wpdb->blogs` b
+			{$cancelled_filter}
 			WHERE
-				`domain` = %s AND
-				`path` LIKE %s
-			ORDER BY `path` DESC
+				b.`domain` = %s AND
+				b.`path` LIKE %s
+				{$cancelled_where}
+			ORDER BY b.`path` DESC
 			LIMIT 1",
 			$current_domain,
 			$latest_path
@@ -217,7 +228,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		return false;
 	}
 
-  $latest_site = $wpdb->get_results( $query ); // phpcs:ignore -- Prepared above.
+	$latest_site = $wpdb->get_results( $query ); // phpcs:ignore -- Prepared above.
 
 	if ( ! $latest_site ) {
 		return false;

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -173,6 +173,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		LEFT JOIN {$central_prefix}posts p ON p.ID = pm.post_id AND p.post_type = 'wordcamp'";
 	$cancelled_where = "AND ( p.post_status IS NULL OR p.post_status != 'wcpt-cancelled' )";
 
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Safe SQL fragments, not user input.
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		// Remove the year prefix.
 		$city_domain = substr(
@@ -227,6 +228,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 	} else {
 		return false;
 	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	$latest_site = $wpdb->get_results( $query ); // phpcs:ignore -- Prepared above.
 

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -105,6 +105,24 @@ class Test_WordCamp_SEO extends Database_TestCase {
 				'/rome/2023/training/',
 				'http://events.wordpress.test/rome/2024/training/',
 			),
+
+			/*
+			 * Cancelled events should be skipped.
+			 *
+			 * 2020.seattle is cancelled, so the latest non-cancelled is 2019.
+			 * vancouver/2021 is cancelled, so the latest non-cancelled is /2020/.
+			 */
+			'year.city should skip cancelled site and return previous year' => array(
+				'2019.seattle.wordcamp.test',
+				'/',
+				'http://2019.seattle.wordcamp.test/',
+			),
+
+			'city/year should skip cancelled site and return previous year' => array(
+				'vancouver.wordcamp.test',
+				'/2018-developers/',
+				'http://vancouver.wordcamp.test/2020/',
+			),
 		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
@@ -39,6 +39,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 			// It should contain an entry for each year.city domain that exist in the database.
 			'2018.seattle.wordcamp.test',
 			'2019.seattle.wordcamp.test',
+			'2020.seattle.wordcamp.test',
 
 			// It should contain a single entry representing all city/year domains that exist in the database.
 			'vancouver.wordcamp.test',
@@ -47,6 +48,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 			'2016.vancouver.wordcamp.test',
 			'2018-developers.vancouver.wordcamp.test',
 			'2020.vancouver.wordcamp.test',
+			'2021.vancouver.wordcamp.test',
 			'2021.japan.wordcamp.test',
 
 			// It should contain old year-less domains.
@@ -125,6 +127,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 			array(
 				'2018.seattle.wordcamp.test',
 				'2019.seattle.wordcamp.test',
+				'2020.seattle.wordcamp.test',
 			),
 			$actual['seattle.wordcamp.test']
 		);
@@ -134,6 +137,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 			array(
 				'2016.vancouver.wordcamp.test',
 				'2020.vancouver.wordcamp.test',
+				'2021.vancouver.wordcamp.test',
 				'2018-developers.vancouver.wordcamp.test',
 			),
 			$actual['vancouver.wordcamp.test']

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise.php
@@ -578,6 +578,24 @@ class Test_Sunrise extends Database_TestCase {
 				'/',
 				'https://vancouver.wordcamp.test/2020/',
 			),
+
+			/*
+			 * Cancelled events should be skipped.
+			 *
+			 * 2020.seattle is cancelled, so the latest non-cancelled is 2019.
+			 * vancouver/2021 is cancelled, so the latest non-cancelled is /2020/.
+			 */
+			'redirect year.city root should skip cancelled and return previous year' => array(
+				'seattle.wordcamp.test',
+				'/',
+				'https://2019.seattle.wordcamp.test/',
+			),
+
+			'redirect city/year root should skip cancelled and return previous year' => array(
+				'vancouver.wordcamp.test',
+				'/',
+				'https://vancouver.wordcamp.test/2020/',
+			),
 		);
 	}
 

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -660,22 +660,29 @@ function get_canonical_year_url( $domain, $path ) {
 }
 
 /**
- * Get the latest site for a given city.
+ * Get the latest site for a given city, skipping cancelled events.
  */
 function get_latest_site( string $domain ) {
 	global $wpdb;
 
+	$central_prefix = $wpdb->get_blog_prefix( WORDCAMP_ROOT_BLOG_ID );
+
 	$latest = $wpdb->get_row( $wpdb->prepare( "
-		SELECT `blog_id`, `domain`, `path`
-		FROM $wpdb->blogs
+		SELECT b.`blog_id`, b.`domain`, b.`path`
+		FROM $wpdb->blogs b
+		LEFT JOIN {$central_prefix}postmeta pm
+			ON pm.meta_key = '_site_id' AND pm.meta_value = b.blog_id
+		LEFT JOIN {$central_prefix}posts p
+			ON p.ID = pm.post_id AND p.post_type = 'wordcamp'
 		WHERE
-  			( public AND NOT deleted ) -- Deleted sites should be skipped
-     			AND
+			( b.public AND NOT b.deleted ) -- Deleted sites should be skipped
+			AND
 			(
-   				( domain =    %s AND path != '/' ) OR -- Match city/year format.
-				( domain LIKE %s AND path  = '/' )    -- Match year.city format.
+				( b.domain =    %s AND b.path != '/' ) OR -- Match city/year format.
+				( b.domain LIKE %s AND b.path  = '/' )    -- Match year.city format.
 			)
-		ORDER BY path DESC, domain DESC
+			AND ( p.post_status IS NULL OR p.post_status != 'wcpt-cancelled' )
+		ORDER BY b.path DESC, b.domain DESC
 		LIMIT 1;",
 		$domain,
 		"%.{$domain}"

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -667,6 +667,7 @@ function get_latest_site( string $domain ) {
 
 	$central_prefix = $wpdb->get_blog_prefix( WORDCAMP_ROOT_BLOG_ID );
 
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Safe table prefix, not user input.
 	$latest = $wpdb->get_row( $wpdb->prepare( "
 		SELECT b.`blog_id`, b.`domain`, b.`path`
 		FROM $wpdb->blogs b
@@ -687,6 +688,7 @@ function get_latest_site( string $domain ) {
 		$domain,
 		"%.{$domain}"
 	) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	return $latest;
 }


### PR DESCRIPTION
## Summary
- Cancelled WordCamp events are no longer used as redirect targets for `city.wordcamp.org` URLs
- Cancelled events are also excluded from the "next edition" banner in latest-site-hints
- Example: `granada.wordcamp.org` will now redirect to the 2024 (completed) event instead of the cancelled 2025 one

## Changes
Two files updated with the same approach:

1. **`sunrise-wordcamp.php` - `get_latest_site()`**: JOIN with the central blog posts/postmeta tables to check WordCamp post status, excluding `wcpt-cancelled`
2. **`latest-site-hints.php` - `get_latest_home_url()`**: Same JOIN pattern applied to all three query variants (year.city, city/year, and events.wordpress.org paths)

Both use LEFT JOINs with a NULL check, so sites without a linked WordCamp post are still included.

## Test plan
- [x] All existing tests pass (305 tests, 570 assertions)
- [ ] Cancel a WordCamp and verify `city.wordcamp.org` redirects to the previous (non-cancelled) edition
- [ ] Verify the "next edition" banner on past sites does not link to cancelled events
- [ ] Verify normal (non-cancelled) redirects still work correctly

Fixes https://github.com/WordPress/wordcamp.org/issues/1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)