### PR TITLE
Fix admin bar overlap with block themes on past sites

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -71,9 +71,9 @@ function canonical_link_past_home_pages_to_current_year() {
  */
 function add_notification_styles() { ?>
   <style type="text/css">
-		html:not(#specificity-hack) {
+		body {
 			/* 44 = 10px x2 for padding, 24px for line height. */
-			margin-top: calc(44px + var(--wp-admin--admin-bar--height, 0px)) !important;
+			margin-top: 44px !important;
 		}
 
 		.wordcamp-latest-site-notify {


### PR DESCRIPTION
Fixes WordPress/wordcamp.org#1289

## Summary

- The "latest site" notification banner in `latest-site-hints.php` was applying `margin-top` with `!important` on the `html` element, combining both the banner height (44px) and the admin bar height via CSS custom property.
- WordPress core already sets `html { margin-top: 32px !important; }` for the admin bar. The mu-plugin was overriding this, which broke admin bar spacing on block themes like Twenty Twenty-Four.
- Moved the 44px banner margin from `html` to `body`, so it no longer conflicts with core's admin bar handling. Both offsets now stack correctly for logged-in and logged-out visitors.

## Test plan

- [ ] Visit a past WordCamp site (one that shows the "next edition" banner) while logged in
- [ ] Verify the admin bar and notification banner do not overlap with page content
- [ ] Test with Twenty Twenty-Four theme specifically
- [ ] Test while logged out (no admin bar) to confirm banner still displays correctly
- [ ] Test on mobile viewport (under 600px) where banner uses position absolute

Generated with Claude Code (https://claude.com/claude-code)