### PR TITLE
Change Venue Name field to textarea for multi-venue support

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Host region'                 => 'textarea',
 
 						// In-person
-						'Venue Name'                 => 'text',
+						'Venue Name'                 => 'textarea',
 						'Physical Address'           => 'textarea',
 						'Maximum Capacity'           => 'text',
 						'Available Rooms'            => 'text',
@@ -590,7 +590,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							'Virtual event only'               => 'checkbox',
 							'Streaming account to use'         => 'select-streaming',
 							'Host region'                      => 'textarea',
-							'Venue Name'                       => 'text',
+							'Venue Name'                       => 'textarea',
 							'Physical Address'                 => 'textarea',
 							'Maximum Capacity'                 => 'text',
 							'Available Rooms'                  => 'text',


### PR DESCRIPTION
## Summary
- Changes the Venue Name field from a single-line text input to a multi-line textarea
- Allows Campus Connect events with multiple venues to list them on separate lines
- Applied to both WordCamp and Campus Connect tracker venue field definitions

## Test plan
- [ ] Edit a WordCamp or Campus Connect event in wp-admin
- [ ] Verify the Venue Name field is now a textarea (multi-line)
- [ ] Enter multiple venues on separate lines and save
- [ ] Verify the data is preserved correctly

Fixes https://github.com/WordPress/wordcamp.org/issues/1604

Generated with [Claude Code](https://claude.com/claude-code)