### PR TITLE
Match schedule thumbnail aspect ratio to singular view

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/functions.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/functions.php
@@ -54,7 +54,7 @@ class WordCamp_Central_Theme {
 
 		// Add some new image sizes, also site shot is 205x148, minimap is 130x70
 		add_image_size( 'wccentral-thumbnail-small', 82, 37, true );
-		add_image_size( 'wccentral-thumbnail-large', 926, 160, true );
+		add_image_size( 'wccentral-thumbnail-large', 926, 418, true );
 		add_image_size( 'wccentral-thumbnail-past', 130, 60, true );
 		add_image_size( 'wccentral-thumbnail-hero', 493, 315, true );
 


### PR DESCRIPTION
## Summary
- Changes the `wccentral-thumbnail-large` image size from 926x160 to 926x418
- This matches the aspect ratio used in the singular WordCamp view, preventing image sides from being cropped in the schedule listing

## Test plan
- [ ] Visit the Central schedule listing page
- [ ] Verify thumbnails no longer crop the sides of banner images
- [ ] Visit a singular WordCamp page and confirm the banner displays correctly
- [ ] Regenerate thumbnails if needed for existing images

Fixes https://github.com/WordPress/wordcamp.org/issues/1617

Generated with [Claude Code](https://claude.com/claude-code)