### PR TITLE
Store favourite sessions in user meta for logged-in users

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -24,8 +24,11 @@ function enqueue_favorite_sessions_dependencies() {
 		'favourite-sessions',
 		'favSessionsPhpObject',
 		array(
-			'root' => esc_url_raw( rest_url() ),
-			'i18n' => array(
+			'root'                  => esc_url_raw( rest_url() ),
+			'nonce'                 => wp_create_nonce( 'wp_rest' ),
+			'isLoggedIn'            => is_user_logged_in(),
+			'preloadedFavSessions'  => is_user_logged_in() ? WordCamp\Post_Types\REST_API\get_preloaded_fav_sessions() : false,
+			'i18n'                  => array(
 				'reqTimeOut'           => esc_html__( 'Sorry, the email request timed out.', 'wordcamporg' ),
 				'otherError'           => esc_html__( 'Sorry, the email request failed.',    'wordcamporg' ),
 				'overwriteFavSessions' => esc_html__( 'You already have some sessions saved. Would you like to overwrite those with the shared sessions that you are viewing?', 'wordcamporg' ),

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -25,6 +25,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\register_additional_rest_fields' 
 add_filter( 'rest_wcb_session_query', __NAMESPACE__ . '\prepare_session_query_args', 10, 2 );
 add_filter( 'rest_wcb_session_collection_params', __NAMESPACE__ . '\add_session_collection_params', 10, 2 );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_fav_sessions_email' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_fav_sessions_user_meta_routes' );
 add_filter( 'rest_prepare_wcb_speaker', __NAMESPACE__ . '\link_speaker_to_sessions', 10, 2 );
 add_filter( 'rest_prepare_wcb_session', __NAMESPACE__ . '\link_session_to_speakers', 10, 2 );
 add_filter( 'rest_avatar_sizes', __NAMESPACE__ . '\add_larger_avatar_sizes' );
@@ -842,6 +843,130 @@ function add_larger_avatar_sizes( $sizes ) {
 	$sizes[] = 512;
 
 	return $sizes;
+}
+
+/**
+ * Register REST API routes for saving/retrieving favourite sessions in user meta.
+ *
+ * This stores favourite sessions per-site in user meta, allowing users to access
+ * their favourites across devices when logged in.
+ *
+ * @return void
+ */
+function register_fav_sessions_user_meta_routes() {
+	register_rest_route(
+		'wc-post-types/v1',
+		'/fav-sessions/',
+		array(
+			array(
+				'methods'             => WP_Rest_Server::READABLE,
+				'callback'            => __NAMESPACE__ . '\get_fav_sessions_user_meta',
+				'permission_callback' => 'is_user_logged_in',
+			),
+			array(
+				'methods'             => WP_Rest_Server::CREATABLE,
+				'callback'            => __NAMESPACE__ . '\save_fav_sessions_user_meta',
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'session_ids' => array(
+						'required'          => true,
+						'validate_callback' => function ( $value ) {
+							if ( ! is_array( $value ) ) {
+								return false;
+							}
+
+							foreach ( $value as $id ) {
+								if ( ! is_numeric( $id ) ) {
+									return false;
+								}
+							}
+
+							return true;
+						},
+						'sanitize_callback' => function ( $value ) {
+							return array_map( 'absint', $value );
+						},
+					),
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get favourite sessions from user meta for the current site.
+ *
+ * @return \WP_REST_Response
+ */
+function get_fav_sessions_user_meta() {
+	$user_id     = get_current_user_id();
+	$meta_key    = get_fav_sessions_meta_key();
+	$session_ids = get_user_meta( $user_id, $meta_key, true );
+
+	if ( ! is_array( $session_ids ) ) {
+		$session_ids = array();
+	}
+
+	return new \WP_REST_Response(
+		array( 'session_ids' => array_map( 'absint', $session_ids ) ),
+		200
+	);
+}
+
+/**
+ * Save favourite sessions to user meta for the current site.
+ *
+ * @param \WP_REST_Request $request REST API Request object.
+ *
+ * @return \WP_REST_Response
+ */
+function save_fav_sessions_user_meta( \WP_REST_Request $request ) {
+	$user_id     = get_current_user_id();
+	$meta_key    = get_fav_sessions_meta_key();
+	$session_ids = $request->get_param( 'session_ids' );
+
+	update_user_meta( $user_id, $meta_key, $session_ids );
+
+	return new \WP_REST_Response(
+		array( 'session_ids' => $session_ids ),
+		200
+	);
+}
+
+/**
+ * Get the user meta key for storing favourite sessions.
+ *
+ * Uses the current blog ID to scope favourites per-site, since each
+ * WordCamp site has its own set of sessions.
+ *
+ * @return string
+ */
+function get_fav_sessions_meta_key() {
+	return 'wc_favourite_sessions_' . get_current_blog_id();
+}
+
+/**
+ * Get pre-loaded favourite sessions data for the current user.
+ *
+ * Used to inline the data in wp_localize_script, avoiding an extra REST API
+ * request on page load.
+ *
+ * @return array|false The session data array, or false if the user is not logged in.
+ */
+function get_preloaded_fav_sessions() {
+	if ( ! is_user_logged_in() ) {
+		return false;
+	}
+
+	$user_id     = get_current_user_id();
+	$meta_key    = get_fav_sessions_meta_key();
+	$session_ids = get_user_meta( $user_id, $meta_key, true );
+
+	if ( ! is_array( $session_ids ) ) {
+		$session_ids = array();
+	}
+
+	return array( 'session_ids' => array_map( 'absint', $session_ids ) );
 }
 
 /**

--- a/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
@@ -20,6 +20,7 @@ jQuery( document ).ready( function ( $ ) {
 		favSessKey: 'favourite_sessions',
 		useLocalStorage: 'local_storage',
 		useUrlSessions:  'URL',
+		syncPending: false,
 
 		get: function() {
 			if ( this.primarySource == this.useLocalStorage ) {
@@ -49,6 +50,7 @@ jQuery( document ).ready( function ( $ ) {
 			}
 
 			localStorage.setItem( this.favSessKey, JSON.stringify( favSessions ) );
+			this.syncToServer();
 		},
 
 		getSessionsForLink: function() {
@@ -74,8 +76,126 @@ jQuery( document ).ready( function ( $ ) {
 			favSessions = this.favSessionsFromUrl();
 
 			localStorage.setItem( this.favSessKey, JSON.stringify( favSessions ) );
+			this.syncToServer();
 
 			return this.get();
+		},
+
+		/**
+		 * Save current favourite sessions to user meta via the REST API.
+		 *
+		 * Only runs when the user is logged in. Debounced to avoid excessive
+		 * requests when toggling multiple sessions quickly.
+		 */
+		syncToServer: function() {
+			if ( ! favSessionsPhpObject.isLoggedIn ) {
+				return;
+			}
+
+			var self = this;
+
+			// Debounce: wait 1 second after the last change before syncing.
+			if ( self.syncTimer ) {
+				clearTimeout( self.syncTimer );
+			}
+
+			self.syncTimer = setTimeout( function() {
+				var favSessions = self.get();
+				var sessionIds = Object.keys( favSessions ).map( Number );
+
+				$.ajax( {
+					method: 'POST',
+					url: favSessionsPhpObject.root + 'wc-post-types/v1/fav-sessions/',
+					data: JSON.stringify( { 'session_ids': sessionIds } ),
+					contentType: 'application/json',
+					beforeSend: function( xhr ) {
+						xhr.setRequestHeader( 'X-WP-Nonce', favSessionsPhpObject.nonce );
+					},
+				} );
+			}, 1000 );
+		},
+
+		/**
+		 * Load favourite sessions from user meta and merge with local storage.
+		 *
+		 * Server data takes precedence when local storage is empty. When both
+		 * have data, they are merged together and synced back to the server.
+		 */
+		loadFromServer: function( callback ) {
+			if ( ! favSessionsPhpObject.isLoggedIn ) {
+				callback();
+				return;
+			}
+
+			var self = this;
+
+			// Use pre-loaded data if available, otherwise fetch from server.
+			var serverData = favSessionsPhpObject.preloadedFavSessions;
+
+			if ( serverData ) {
+				self.mergeServerData( serverData );
+				callback();
+			} else {
+				$.ajax( {
+					method: 'GET',
+					url: favSessionsPhpObject.root + 'wc-post-types/v1/fav-sessions/',
+					beforeSend: function( xhr ) {
+						xhr.setRequestHeader( 'X-WP-Nonce', favSessionsPhpObject.nonce );
+					},
+					success: function( response ) {
+						self.mergeServerData( response );
+						callback();
+					},
+					error: function() {
+						// If server request fails, just use local storage.
+						callback();
+					},
+				} );
+			}
+		},
+
+		/**
+		 * Merge server response data with local storage.
+		 */
+		mergeServerData: function( response ) {
+			var serverSessionIds = response.session_ids || [];
+			var localSessions = JSON.parse( localStorage.getItem( this.favSessKey ) ) || {};
+			var localSessionIds = Object.keys( localSessions );
+			var merged = {};
+			var needsSync = false;
+			var i;
+
+			// If local storage is empty, use server data.
+			if ( localSessionIds.length === 0 && serverSessionIds.length > 0 ) {
+				for ( i = 0; i < serverSessionIds.length; i++ ) {
+					merged[ serverSessionIds[ i ] ] = true;
+				}
+				localStorage.setItem( this.favSessKey, JSON.stringify( merged ) );
+			} else if ( localSessionIds.length > 0 && serverSessionIds.length === 0 ) {
+				// Local has data but server is empty, sync local to server.
+				needsSync = true;
+			} else if ( localSessionIds.length > 0 && serverSessionIds.length > 0 ) {
+				// Both have data, merge them.
+				merged = localSessions;
+				for ( i = 0; i < serverSessionIds.length; i++ ) {
+					if ( ! merged.hasOwnProperty( serverSessionIds[ i ] ) ) {
+						merged[ serverSessionIds[ i ] ] = true;
+						needsSync = true;
+					}
+				}
+				localStorage.setItem( this.favSessKey, JSON.stringify( merged ) );
+
+				// Check if server needs sessions that only exist locally.
+				for ( i = 0; i < localSessionIds.length; i++ ) {
+					if ( serverSessionIds.indexOf( parseInt( localSessionIds[ i ] ) ) === -1 ) {
+						needsSync = true;
+					}
+				}
+			}
+
+			if ( needsSync ) {
+				this.syncToServer();
+			}
 		},
 	};
 
@@ -156,19 +276,27 @@ jQuery( document ).ready( function ( $ ) {
 	}
 
 	function initFavouriteSessions() {
+		var currentUrl = window.location.href;
+
+		// If viewing a shared link, handle that immediately without waiting for server.
+		if ( currentUrl.indexOf( favSessionsUrlSlug ) > -1 ) {
+			initFromUrlOrLocalStorage();
+			return;
+		}
+
+		// Load from server first (merges with local storage), then render.
+		FavSessionsStore.loadFromServer( function() {
+			initFromUrlOrLocalStorage();
+		} );
+	}
+
+	function initFromUrlOrLocalStorage() {
 		var favSessions = FavSessionsStore.get();
 
 		if ( favSessions === {} ) {
 			return;
 		}
 
-		/*
-		 * The user has already saved some sessions in local storage, but is now
-		 * loading a shared link. We need to determine whether they intend to overwrite
-		 * their saved sessions with those in the link, or if they just want to view
-		 * the link's sessions and then discard them, so that their saved sessions remain
-		 * in tact.
-		 */
 		var currentUrl = window.location.href;
 
 		if ( currentUrl.indexOf( favSessionsUrlSlug ) > -1 ) {


### PR DESCRIPTION
## Summary

- Adds REST API endpoints (`GET`/`POST` at `wc-post-types/v1/fav-sessions/`) to store and retrieve favourite sessions in user meta, scoped per-site using `wc_favourite_sessions_{blog_id}` as the meta key.
- On page load for logged-in users, pre-loads server-side favourites inline via `wp_localize_script` (no extra REST API request) and merges them with local storage (local storage continues to work as before for logged-out users).
- Syncs changes to the server (debounced at 1 second) whenever a logged-in user toggles a session favourite.
- Passes `nonce`, `isLoggedIn`, and `preloadedFavSessions` to the JS via `wp_localize_script` to enable authenticated REST requests.
- Simplified `permission_callback` to use `'is_user_logged_in'` string instead of anonymous closures.

This allows users to access their favourite sessions across devices by signing in, while preserving full backwards compatibility with the existing local storage approach for logged-out visitors.

Fixes WordPress/wordcamp.org#1629

## Test plan

- [ ] Verify logged-out users can still favourite sessions using local storage only (no REST API calls made)
- [ ] Verify logged-in users see their favourites saved to user meta via pre-loaded data (no GET request on page load)
- [ ] Verify toggling a favourite as a logged-in user triggers a `POST` to save to user meta
- [ ] Verify favourites from local storage merge with server data on page load
- [ ] Verify favourites sync across devices when logged in with the same account
- [ ] Verify shared link (`?fav-sessions=...`) still works correctly without waiting for server
- [ ] Verify the debounce works (rapid toggling only sends one request)


Generated with [Claude Code](https://claude.com/claude-code)