### PR TITLE
Rename venue Contact Information to Contact Email Address

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -762,18 +762,21 @@ abstract class Event_Admin {
 	 * @param array $messages List of messages to displayed by a key.
 	 * @param int   $post_id ID of post.
 	 * @param array $protected_fields List of read only fields.
+	 * @param array $labels Optional. Display labels keyed by meta key, to override the default key-as-label.
 	 */
 	public static function display_meta_boxes(
 		$required_fields,
 		$meta_keys,
 		$messages,
 		$post_id,
-		$protected_fields
+		$protected_fields,
+		$labels = array()
 	) {
 
 		foreach ( $meta_keys as $key => $value ) :
 			$object_name = wcpt_key_to_str( $key, 'wcpt_' );
 			$readonly    = in_array( $key, $protected_fields ) ? ' readonly="readonly"' : '';
+			$label       = isset( $labels[ $key ] ) ? $labels[ $key ] : $key;
 			$classes     = array(
 				'inside',
 				'wcpt-field',
@@ -788,7 +791,7 @@ abstract class Event_Admin {
 
 					<p>
 						<label>
-							<strong><?php echo esc_html( $key ); ?></strong>:
+							<strong><?php echo esc_html( $label ); ?></strong>:
 							<input
 								type="checkbox"
 								name="<?php echo esc_attr( $object_name ); ?>"
@@ -805,7 +808,7 @@ abstract class Event_Admin {
 				<?php else : ?>
 
 					<p>
-						<label for="<?php echo esc_attr( $object_name ); ?>"><?php echo esc_html( $key ); ?></label>
+						<label for="<?php echo esc_attr( $object_name ); ?>"><?php echo esc_html( $label ); ?></label>
 						<?php if ( in_array( $key, $required_fields, true ) ) : ?>
 							<span class="description"><?php esc_html_e( '(required)', 'wordcamporg' ); ?></span>
 						<?php endif; ?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1151,6 +1151,11 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'Budget Wrangler E-mail Address',
 			);
 
+			// Venue Contact Information is required for Campus Connect events.
+			if ( 'campusconnect' === get_post_meta( $post_id, 'event_subtype', true ) ) {
+				$scheduled[] = 'Contact Information';
+			}
+
 			// Required because the Events Widget needs a physical address in order to show events.
 			$scheduled[] = self::get_address_key( $post_id );
 
@@ -1701,5 +1706,10 @@ function wcpt_metabox( $meta_keys, $metabox ) {
 		$messages['Host region']      = $address_instructions;
 	}
 
-	Event_Admin::display_meta_boxes( $required_fields, $meta_keys, $messages, $post_id, WordCamp_Admin::get_protected_fields() );
+	// Override display labels for specific meta keys.
+	$labels = array(
+		'Contact Information' => 'Contact Email Address',
+	);
+
+	Event_Admin::display_meta_boxes( $required_fields, $meta_keys, $messages, $post_id, WordCamp_Admin::get_protected_fields(), $labels );
 }


### PR DESCRIPTION
## Summary

- Renames the venue "Contact Information" field label to "Contact Email Address" in the admin UI, while preserving the existing `Contact Information` meta key for backward compatibility with stored data.
- Makes this field mandatory before status can change to "Scheduled" for Campus Connect events, ensuring a specific point of contact is collected for each campus.
- Adds a `$labels` parameter to `display_meta_boxes()` so field display names can differ from stored meta keys.

Fixes WordPress/wordcamp.org#1598

## Test plan

- [ ] Open a Campus Connect event in the admin and verify the venue section shows "Contact Email Address" instead of "Contact Information"
- [ ] Verify that trying to change a Campus Connect event status to "Scheduled" without filling in the Contact Email Address field shows a validation error
- [ ] Verify that non-Campus Connect events (WordCamp, Meetup) do not require the Contact Email Address field for Scheduled status
- [ ] Verify that existing data saved under the "Contact Information" meta key still loads correctly in the renamed field

Generated with [Claude Code](https://claude.com/claude-code)