### PR TITLE
Fix schedule thumbnail aspect ratio for wide banners

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -1570,6 +1570,12 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	-webkit-box-shadow: 0px 1px 4px #75888a;
 }
 
+.wc-schedule .wc-schedule-list img.wc-image {
+	width: 82px;
+	height: 37px;
+	object-fit: cover;
+}
+
 #ie7 .wc-schedule .wc-schedule-list img,
 #ie8 .wc-schedule .wc-schedule-list img,
 #ie7 .wc-schedule .wc-schedule-list div,

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
@@ -66,7 +66,7 @@ get_header(); ?>
 								<li>
 									<a href="<?php echo esc_url( WordCamp_Central_Theme::get_best_wordcamp_url( $post->ID ) ); ?>">
 										<?php if ( has_post_thumbnail() ) : ?>
-											<?php the_post_thumbnail( 'wccentral-thumbnail-small', array( 'class' => 'wc-image' ) ); ?>
+											<?php the_post_thumbnail( 'wccentral-thumbnail-large', array( 'class' => 'wc-image' ) ); ?>
 										<?php else : ?>
 											<div class="wc-image wp-post-image wordcamp-placeholder-thumb" title="<?php the_title(); ?>"></div>
 										<?php endif; ?>


### PR DESCRIPTION
## Summary

- Use `wccentral-thumbnail-large` (926x160) instead of `wccentral-thumbnail-small` (82x37) for schedule listing thumbnails. The large size preserves the full width of banner images (1852x320), preventing sides from being cut off.
- Add CSS `object-fit: cover` rule to constrain the larger image to the original 82x37 display size, so the visual layout remains unchanged.
- No `add_image_size()` changes needed -- this uses an existing image size that already matches the banner aspect ratio.

## Why this approach

The previous attempt (PR #44) changed the registered image size dimensions, which would require regenerating all thumbnails. This approach instead uses an already-existing larger image size and relies on CSS to handle the display sizing, avoiding any thumbnail regeneration.

## Test plan

- Verify schedule page at `/schedule/` shows thumbnails at the same 82x37 visual size
- Upload a wide banner image (1852x320) and confirm the thumbnail shows the full banner width without sides being cropped
- Verify events without thumbnails still show the placeholder correctly

Fixes WordPress/wordcamp.org#1617

Generated with [Claude Code](https://claude.com/claude-code)