### PR TITLE
Add language filter to WordCamp admin list view

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -78,6 +78,10 @@ abstract class Event_Admin {
 		add_filter( 'posts_search', array( $this, 'extend_search_to_postmeta' ), 10, 2 );
 		add_filter( 'posts_join', array( $this, 'search_postmeta_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( $this, 'search_postmeta_groupby' ), 10, 2 );
+
+		// Language filter on the admin list table.
+		add_action( 'restrict_manage_posts', array( $this, 'add_language_filter_dropdown' ) );
+		add_action( 'parse_query', array( $this, 'filter_by_language' ) );
 	}
 
 	/**
@@ -587,7 +591,7 @@ abstract class Event_Admin {
 					break;
 
 				case 'select-locale':
-					$allowed_locales = array_keys( WordCamp_Admin::get_locale_options() );
+					$allowed_locales = array_keys( self::get_locale_options() );
 					$new_value       = array();
 
 					if ( is_array( $values[ $key ] ) ) {
@@ -970,7 +974,7 @@ abstract class Event_Admin {
 								break;
 							case 'select-locale':
 								$selected_locales = get_post_meta( $post_id, $key, true );
-								$locales          = WordCamp_Admin::get_locale_options();
+								$locales          = self::get_locale_options();
 
 								if ( ! is_array( $selected_locales ) ) {
 									$selected_locales = array();
@@ -1189,5 +1193,100 @@ abstract class Event_Admin {
 		}
 
 		return $groupby;
+	}
+
+	/**
+	 * Get available locale options for the Language field.
+	 *
+	 * Uses GlotPress locales if available, otherwise falls back to
+	 * wp_get_available_translations().
+	 *
+	 * @return array Associative array of locale code => display name.
+	 */
+	public static function get_locale_options() {
+		if ( defined( 'GLOTPRESS_LOCALES_PATH' ) && file_exists( GLOTPRESS_LOCALES_PATH ) ) {
+			require_once GLOTPRESS_LOCALES_PATH;
+
+			$locales = GP_Locales::locales();
+			$options = array();
+
+			foreach ( $locales as $locale ) {
+				if ( ! empty( $locale->wp_locale ) ) {
+					$options[ $locale->wp_locale ] = $locale->english_name;
+				}
+			}
+
+			asort( $options );
+
+			return $options;
+		}
+
+		// Fallback: use WordPress available translations.
+		if ( ! function_exists( 'wp_get_available_translations' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+		}
+
+		$translations = wp_get_available_translations();
+		$options      = array( 'en_US' => 'English (United States)' );
+
+		foreach ( $translations as $locale => $data ) {
+			$options[ $locale ] = $data['english_name'];
+		}
+
+		asort( $options );
+
+		return $options;
+	}
+
+	/**
+	 * Add a Language filter dropdown to the admin list table.
+	 *
+	 * @param string $post_type The current post type.
+	 */
+	public function add_language_filter_dropdown( $post_type ) {
+		if ( $this->get_event_type() !== $post_type ) {
+			return;
+		}
+
+		$locales  = self::get_locale_options();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only filter for list table.
+		$selected = isset( $_GET['language'] ) ? sanitize_text_field( wp_unslash( $_GET['language'] ) ) : '';
+
+		?>
+		<select name="language" id="filter-by-language">
+			<option value=""><?php esc_html_e( 'All Languages', 'wordcamporg' ); ?></option>
+			<?php foreach ( $locales as $locale_code => $locale_name ) : ?>
+				<option value="<?php echo esc_attr( $locale_code ); ?>" <?php selected( $selected, $locale_code ); ?>>
+					<?php echo esc_html( $locale_name ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Filter the admin list by Language.
+	 *
+	 * @param WP_Query $query The current query.
+	 */
+	public function filter_by_language( $query ) {
+		if (
+			! $query->is_main_query() ||
+			$this->get_event_type() !== $query->get( 'post_type' ) ||
+			empty( $_REQUEST['language'] )
+		) {
+			return;
+		}
+
+		$language = sanitize_text_field( wp_unslash( $_REQUEST['language'] ) );
+
+		$meta_query   = $query->get( 'meta_query' ) ?: array();
+		$meta_query[] = array(
+			'key'     => 'Language',
+			'value'   => $language,
+			'compare' => 'LIKE',
+		);
+
+		$query->set( 'meta_query', $meta_query );
 	}
 }

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -586,6 +586,21 @@ abstract class Event_Admin {
 					update_post_meta( $post_id, $key, $new_value );
 					break;
 
+				case 'select-locale':
+					$allowed_locales = array_keys( WordCamp_Admin::get_locale_options() );
+					$new_value       = array();
+
+					if ( is_array( $values[ $key ] ) ) {
+						foreach ( $values[ $key ] as $locale ) {
+							if ( in_array( $locale, $allowed_locales, true ) ) {
+								$new_value[] = $locale;
+							}
+						}
+					}
+
+					update_post_meta( $post_id, $key, $new_value );
+					break;
+
 				case 'select-streaming':
 					$allowed_values = array_keys( self::get_streaming_services() );
 					$key_other      = wcpt_key_to_str( $key, 'wcpt_' ) . '-other';
@@ -952,6 +967,33 @@ abstract class Event_Admin {
 										'show_option_none' => 'None',
 									)
 								);
+								break;
+							case 'select-locale':
+								$selected_locales = get_post_meta( $post_id, $key, true );
+								$locales          = WordCamp_Admin::get_locale_options();
+
+								if ( ! is_array( $selected_locales ) ) {
+									$selected_locales = array();
+								}
+								?>
+
+								<select
+									name="<?php echo esc_attr( $object_name ); ?>[]"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									multiple
+									style="height: auto; min-height: 120px;"
+								>
+									<?php foreach ( $locales as $locale_code => $locale_name ) : ?>
+										<option
+											value="<?php echo esc_attr( $locale_code ); ?>"
+											<?php selected( in_array( $locale_code, $selected_locales, true ) ); ?>
+										>
+											<?php echo esc_html( $locale_name ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+
+								<?php
 								break;
 							case 'select-streaming':
 								$selected = get_post_meta( $post_id, $key, true );

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -678,6 +678,7 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				'Date closed'           => 'date',
 				'Slack'                 => 'text',
 				'Region'                => 'text',
+				'Language'              => 'select-locale',
 				'Address'               => 'textarea',
 				'Extra Comments'        => 'textarea',
 			);

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -53,10 +53,6 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			add_filter( 'views_edit-wordcamp', array( $this, 'alter_views' ) );
 			add_action( 'parse_query', array( $this, 'filter_by_subtype' ) );
 
-			// Language filter on the WordCamp list table.
-			add_action( 'restrict_manage_posts', array( $this, 'add_language_filter_dropdown' ) );
-			add_action( 'parse_query', array( $this, 'filter_by_language' ) );
-
 			// Cron jobs.
 			add_action( 'plugins_loaded', array( $this, 'schedule_cron_jobs' ), 11 );
 			add_action( 'wcpt_close_wordcamps_after_event', array( $this, 'close_wordcamps_after_event' ) );
@@ -1622,100 +1618,6 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			$query->set( 'meta_query', $meta_query );
 		}
 
-		/**
-		 * Get available locale options for the Language field.
-		 *
-		 * Uses GlotPress locales if available, otherwise falls back to
-		 * wp_get_available_translations().
-		 *
-		 * @return array Associative array of locale code => display name.
-		 */
-		public static function get_locale_options() {
-			if ( defined( 'GLOTPRESS_LOCALES_PATH' ) && file_exists( GLOTPRESS_LOCALES_PATH ) ) {
-				require_once GLOTPRESS_LOCALES_PATH;
-
-				$locales = GP_Locales::locales();
-				$options = array();
-
-				foreach ( $locales as $locale ) {
-					if ( ! empty( $locale->wp_locale ) ) {
-						$options[ $locale->wp_locale ] = $locale->english_name;
-					}
-				}
-
-				asort( $options );
-
-				return $options;
-			}
-
-			// Fallback: use WordPress available translations.
-			if ( ! function_exists( 'wp_get_available_translations' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/translation-install.php';
-			}
-
-			$translations = wp_get_available_translations();
-			$options      = array( 'en_US' => 'English (United States)' );
-
-			foreach ( $translations as $locale => $data ) {
-				$options[ $locale ] = $data['english_name'];
-			}
-
-			asort( $options );
-
-			return $options;
-		}
-
-		/**
-		 * Add a Language filter dropdown to the WordCamp list table.
-		 *
-		 * @param string $post_type The current post type.
-		 */
-		public function add_language_filter_dropdown( $post_type ) {
-			if ( WCPT_POST_TYPE_ID !== $post_type ) {
-				return;
-			}
-
-			$locales  = self::get_locale_options();
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only filter for list table.
-			$selected = isset( $_GET['language'] ) ? sanitize_text_field( wp_unslash( $_GET['language'] ) ) : '';
-
-			?>
-			<select name="language" id="filter-by-language">
-				<option value=""><?php esc_html_e( 'All Languages', 'wordcamporg' ); ?></option>
-				<?php foreach ( $locales as $locale_code => $locale_name ) : ?>
-					<option value="<?php echo esc_attr( $locale_code ); ?>" <?php selected( $selected, $locale_code ); ?>>
-						<?php echo esc_html( $locale_name ); ?>
-					</option>
-				<?php endforeach; ?>
-			</select>
-			<?php
-		}
-
-		/**
-		 * Filter the WordCamp list by Language.
-		 *
-		 * @param WP_Query $query The current query.
-		 */
-		public function filter_by_language( $query ) {
-			if (
-				! $query->is_main_query() ||
-				WCPT_POST_TYPE_ID !== $query->get( 'post_type' ) ||
-				empty( $_REQUEST['language'] )
-			) {
-				return;
-			}
-
-			$language = sanitize_text_field( wp_unslash( $_REQUEST['language'] ) );
-
-			$meta_query   = $query->get( 'meta_query' ) ?: array();
-			$meta_query[] = array(
-				'key'     => 'Language',
-				'value'   => $language,
-				'compare' => 'LIKE',
-			);
-
-			$query->set( 'meta_query', $meta_query );
-		}
 	}
 endif; // class_exists check.
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -53,6 +53,10 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			add_filter( 'views_edit-wordcamp', array( $this, 'alter_views' ) );
 			add_action( 'parse_query', array( $this, 'filter_by_subtype' ) );
 
+			// Language filter on the WordCamp list table.
+			add_action( 'restrict_manage_posts', array( $this, 'add_language_filter_dropdown' ) );
+			add_action( 'parse_query', array( $this, 'filter_by_language' ) );
+
 			// Cron jobs.
 			add_action( 'plugins_loaded', array( $this, 'schedule_cron_jobs' ), 11 );
 			add_action( 'wcpt_close_wordcamps_after_event', array( $this, 'close_wordcamps_after_event' ) );
@@ -469,6 +473,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'WordCamp Hashtag'                  => 'text',
 						'Number of Anticipated Attendees'   => 'text',
 						'Actual Attendees'                  => 'number',
+						'Language'                          => 'select-locale',
 						'Multi-Event Sponsor Region'        => 'mes-dropdown',
 						'Global Sponsorship Grant Currency' => 'select-currency',
 						'Global Sponsorship Grant Amount'   => 'number',
@@ -515,6 +520,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'WordCamp Hashtag'                  => 'text',
 						'Number of Anticipated Attendees'   => 'text',
 						'Actual Attendees'                  => 'number',
+						'Language'                          => 'select-locale',
 						'Multi-Event Sponsor Region'        => 'mes-dropdown',
 						'Global Sponsorship Grant Currency' => 'select-currency',
 						'Global Sponsorship Grant Amount'   => 'number',
@@ -1611,6 +1617,101 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'key'     => 'event_subtype',
 				'value'   => $type,
 				'compare' => '=',
+			);
+
+			$query->set( 'meta_query', $meta_query );
+		}
+
+		/**
+		 * Get available locale options for the Language field.
+		 *
+		 * Uses GlotPress locales if available, otherwise falls back to
+		 * wp_get_available_translations().
+		 *
+		 * @return array Associative array of locale code => display name.
+		 */
+		public static function get_locale_options() {
+			if ( defined( 'GLOTPRESS_LOCALES_PATH' ) && file_exists( GLOTPRESS_LOCALES_PATH ) ) {
+				require_once GLOTPRESS_LOCALES_PATH;
+
+				$locales = GP_Locales::locales();
+				$options = array();
+
+				foreach ( $locales as $locale ) {
+					if ( ! empty( $locale->wp_locale ) ) {
+						$options[ $locale->wp_locale ] = $locale->english_name;
+					}
+				}
+
+				asort( $options );
+
+				return $options;
+			}
+
+			// Fallback: use WordPress available translations.
+			if ( ! function_exists( 'wp_get_available_translations' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+			}
+
+			$translations = wp_get_available_translations();
+			$options      = array( 'en_US' => 'English (United States)' );
+
+			foreach ( $translations as $locale => $data ) {
+				$options[ $locale ] = $data['english_name'];
+			}
+
+			asort( $options );
+
+			return $options;
+		}
+
+		/**
+		 * Add a Language filter dropdown to the WordCamp list table.
+		 *
+		 * @param string $post_type The current post type.
+		 */
+		public function add_language_filter_dropdown( $post_type ) {
+			if ( WCPT_POST_TYPE_ID !== $post_type ) {
+				return;
+			}
+
+			$locales  = self::get_locale_options();
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only filter for list table.
+			$selected = isset( $_GET['language'] ) ? sanitize_text_field( wp_unslash( $_GET['language'] ) ) : '';
+
+			?>
+			<select name="language" id="filter-by-language">
+				<option value=""><?php esc_html_e( 'All Languages', 'wordcamporg' ); ?></option>
+				<?php foreach ( $locales as $locale_code => $locale_name ) : ?>
+					<option value="<?php echo esc_attr( $locale_code ); ?>" <?php selected( $selected, $locale_code ); ?>>
+						<?php echo esc_html( $locale_name ); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+			<?php
+		}
+
+		/**
+		 * Filter the WordCamp list by Language.
+		 *
+		 * @param WP_Query $query The current query.
+		 */
+		public function filter_by_language( $query ) {
+			if (
+				! $query->is_main_query() ||
+				WCPT_POST_TYPE_ID !== $query->get( 'post_type' ) ||
+				empty( $_REQUEST['language'] )
+			) {
+				return;
+			}
+
+			$language = sanitize_text_field( wp_unslash( $_REQUEST['language'] ) );
+
+			$meta_query   = $query->get( 'meta_query' ) ?: array();
+			$meta_query[] = array(
+				'key'     => 'Language',
+				'value'   => $language,
+				'compare' => 'LIKE',
 			);
 
 			$query->set( 'meta_query', $meta_query );

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1617,7 +1617,6 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 			$query->set( 'meta_query', $meta_query );
 		}
-
 	}
 endif; // class_exists check.
 


### PR DESCRIPTION
## Summary

- Adds a "Language" meta field (`select-locale`) to the WordCamp post type, stored as a WordPress locale code (e.g. `en_US`, `de_DE`)
- Adds a "Language" dropdown in the WordCamp editor meta box so organizers/wranglers can set the event language
- Adds an "All Languages" filter dropdown on the WordCamp admin list table for filtering by language

This is the admin-side foundation for WordPress/wordcamp.org#1647. Future work could expose this field via the REST API and add language filtering to the public events page.

## Screenshots

**Before** — no language filter:
![Before](https://raw.githubusercontent.com/dd32/wordcamp.org/7d89a7ec/pr51-before.png)

**After** — "All Languages" dropdown added:
![After](https://raw.githubusercontent.com/dd32/wordcamp.org/7d89a7ec/pr51-after.png)

## Test plan

- Verify the "Language" dropdown appears in the WordCamp editor meta box
- Set a language on a WordCamp and confirm it saves correctly
- Verify the "All Languages" dropdown appears on the WordCamp list table (next to the date/status filters)
- Select a language and filter; confirm only matching WordCamps appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)