### PR TITLE
Harden payment gateway plugin requirements in CampTix

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7778,6 +7778,33 @@ class CampTix_Plugin {
 	}
 
 	/**
+	 * Updates a meta value for all attendees associated with a payment token.
+	 *
+	 * This is a helper to avoid duplicating the pattern of fetching attendees by
+	 * payment token and then updating meta for each one. Payment gateways often
+	 * need to store a checkout session or payment ID with all attendees in an order.
+	 *
+	 * @param string $payment_token The payment token.
+	 * @param string $meta_key      The meta key to update.
+	 * @param mixed  $meta_value    The meta value to set.
+	 *
+	 * @return bool True if attendees were found and updated, false otherwise.
+	 */
+	function update_attendees_for_payment_token( $payment_token, $meta_key, $meta_value ) {
+		$attendees = $this->get_attendees_from_payment_token( $payment_token );
+
+		if ( empty( $attendees ) ) {
+			return false;
+		}
+
+		foreach ( $attendees as $attendee ) {
+			update_post_meta( $attendee->ID, $meta_key, $meta_value );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Returns a payment method class object by id/key.
 	 */
 	function get_payment_method_by_id( $id ) {
@@ -7823,6 +7850,34 @@ class CampTix_Plugin {
 	function payment_result( $payment_token, $result, $data = array(), $interactive = true ) {
 		if ( empty( $payment_token ) )
 			die( 'Do not call payment_result without a payment token.' );
+
+		// Validate that $data is properly structured for payment statuses that should include transaction data.
+		$statuses_requiring_transaction_data = array(
+			self::PAYMENT_STATUS_COMPLETED,
+			self::PAYMENT_STATUS_PENDING,
+		);
+
+		if (
+			! empty( $data ) &&
+			in_array( $result, $statuses_requiring_transaction_data, true ) &&
+			! array_key_exists( 'transaction_id', $data )
+		) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					'Payment data should be a structured array with "transaction_id" and "transaction_details" keys. Received keys: %s',
+					implode( ', ', array_keys( $data ) )
+				),
+				'CampTix 1.7'
+			);
+
+			$this->log(
+				sprintf( 'Payment gateway passed unstructured data to payment_result. Keys: %s', implode( ', ', array_keys( $data ) ) ),
+				0,
+				$data,
+				'payment'
+			);
+		}
 
 		$attendees = get_posts( array(
 			'posts_per_page' => -1,

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -230,10 +230,10 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 		$refund_data = array();
 
 		_doing_it_wrong(
-			get_class( $this ) . '::payment_refund',
+			esc_html( get_class( $this ) ) . '::payment_refund',
 			sprintf(
 				'Payment gateway "%s" has not implemented refund support. Payment gateways should implement the payment_refund() method.',
-				$this->name
+				esc_html( $this->name )
 			),
 			'CampTix 1.7'
 		);
@@ -262,10 +262,10 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 		);
 
 		_doing_it_wrong(
-			get_class( $this ) . '::send_refund_request',
+			esc_html( get_class( $this ) ) . '::send_refund_request',
 			sprintf(
 				'Payment gateway "%s" has not implemented refund support. Payment gateways should implement the send_refund_request() method.',
-				$this->name
+				esc_html( $this->name )
 			),
 			'CampTix 1.7'
 		);

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -87,7 +87,7 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 		global $camptix;
 
 		// Whitelist the methods we want to use to avoid unintentionally calling CampTix_Plugin methods in case of typos, etc
-		$camptix_methods = array( 'payment_result', 'redirect_with_error_flags', 'error_flag', 'get_tickets_url', 'log', 'field_text', 'field_checkbox', 'field_yesno' );
+		$camptix_methods = array( 'payment_result', 'redirect_with_error_flags', 'error_flag', 'get_tickets_url', 'log', 'field_text', 'field_checkbox', 'field_yesno', 'update_attendees_for_payment_token' );
 
 		if ( in_array( $name, $camptix_methods ) ) {
 			// Set a default value for the log $module parameter
@@ -228,7 +228,17 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 		global $camptix;
 
 		$refund_data = array();
-		$camptix->log( __FUNCTION__ . ' not implemented in payment module.', 0, null, 'refund' );
+
+		_doing_it_wrong(
+			get_class( $this ) . '::payment_refund',
+			sprintf(
+				'Payment gateway "%s" has not implemented refund support. Payment gateways should implement the payment_refund() method.',
+				$this->name
+			),
+			'CampTix 1.7'
+		);
+
+		$camptix->log( __FUNCTION__ . ' not implemented in payment module ' . get_class( $this ) . '.', 0, null, 'refund' );
 
 		return $this->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_REFUND_FAILED, $refund_data );
 	}
@@ -251,7 +261,16 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 			'refund_transaction_details' => array(),
 		);
 
-		$camptix->log( __FUNCTION__ . ' not implemented in payment module.', 0, null, 'refund' );
+		_doing_it_wrong(
+			get_class( $this ) . '::send_refund_request',
+			sprintf(
+				'Payment gateway "%s" has not implemented refund support. Payment gateways should implement the send_refund_request() method.',
+				$this->name
+			),
+			'CampTix 1.7'
+		);
+
+		$camptix->log( __FUNCTION__ . ' not implemented in payment module ' . get_class( $this ) . '.', 0, null, 'refund' );
 		return $result;
 	}
 


### PR DESCRIPTION
## Summary

Addresses WordPress/wordcamp.org#1550 by adding validation and deprecation notices to enforce proper payment gateway behavior in CampTix.

- **Validate `payment_result()` data structure**: When a gateway passes data for completed/pending payments, it now checks for the required `transaction_id` key and triggers `_doing_it_wrong()` plus a CampTix log entry when the data is unstructured (e.g. raw `$_GET` instead of `[ "transaction_id" => ..., "transaction_details" => [...] ]`). This is a deprecation warning rather than a hard rejection to avoid breaking existing gateways.
- **Deprecation notices for missing refund support**: The base `payment_refund()` and `send_refund_request()` methods now emit `_doing_it_wrong()` notices with the gateway class name, making it clear which gateway lacks refund support.
- **New helper: `update_attendees_for_payment_token()`**: Adds a method to `CampTix_Plugin` that updates a meta value for all attendees in a payment token group, reducing the duplicated pattern of fetching attendees and iterating to update meta. Also exposed to gateways via the `__call` whitelist.

## Test plan

- [ ] Verify that a properly structured `payment_result()` call (with `transaction_id` key) does not trigger any warnings
- [ ] Verify that an improperly structured call (e.g. passing raw `$_GET`) triggers `_doing_it_wrong` and logs the issue
- [ ] Verify that calling the base `payment_refund()` on a gateway without refund support triggers the deprecation notice
- [ ] Verify that `update_attendees_for_payment_token()` correctly updates meta for all attendees sharing a token

Generated with [Claude Code](https://claude.com/claude-code)