### PR TITLE
Add partial refund support for multi-ticket CampTix orders

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
@@ -746,7 +746,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 	 *
 	 * @return int One of the CampTix_Plugin::PAYMENT_STATUS_{status} constants
 	 */
-	function payment_refund( $payment_token, $refund_amount = 0 ) {
+	public function payment_refund( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
 
@@ -785,7 +785,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 		return $camptix->payment_result( $payment_token, $result['status'], $refund_data );
 	}
 
-	/*
+	/**
 	 * Sends a request to PayPal to refund a transaction
 	 *
 	 * @param string    $payment_token
@@ -794,7 +794,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 	 *
 	 * @return array
 	 */
-	function send_refund_request( $payment_token, $refund_amount = 0 ) {
+	public function send_refund_request( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
@@ -740,15 +740,17 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 	/**
 	 * Submits a single, user-initiated refund request to PayPal and returns the result
 	 *
-	 * @param string $payment_token
+	 * @param string    $payment_token
+	 * @param float|int $refund_amount Optional. The amount to refund in the base currency unit (e.g. dollars).
+	 *                                 If 0 or not provided, a full refund is issued.
 	 *
 	 * @return int One of the CampTix_Plugin::PAYMENT_STATUS_{status} constants
 	 */
-	function payment_refund( $payment_token ) {
+	function payment_refund( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
 
-		$result = $this->send_refund_request( $payment_token );
+		$result = $this->send_refund_request( $payment_token, $refund_amount );
 
 		if ( CampTix_Plugin::PAYMENT_STATUS_REFUNDED != $result['status'] ) {
 			$error_code    = isset( $result['refund_transaction_details']['L_ERRORCODE0'] )   ? $result['refund_transaction_details']['L_ERRORCODE0']   : 0;
@@ -771,17 +773,28 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 			),
 		);
 
+		// For partial refunds, store result data so the caller can use it
+		// without payment_result marking all attendees as refunded.
+		if ( $refund_amount > 0 && CampTix_Plugin::PAYMENT_STATUS_REFUNDED == $result['status'] ) {
+			$camptix->tmp( 'refund_transaction_id', $refund_data['refund_transaction_id'] );
+			$camptix->tmp( 'refund_transaction_details', $refund_data['refund_transaction_details'] );
+
+			return CampTix_Plugin::PAYMENT_STATUS_REFUNDED;
+		}
+
 		return $camptix->payment_result( $payment_token, $result['status'], $refund_data );
 	}
 
 	/*
 	 * Sends a request to PayPal to refund a transaction
 	 *
-	 * @param string $payment_token
+	 * @param string    $payment_token
+	 * @param float|int $refund_amount Optional. The amount to refund in the base currency unit (e.g. dollars).
+	 *                                 If 0 or not provided, a full refund is issued.
 	 *
 	 * @return array
 	 */
-	function send_refund_request( $payment_token ) {
+	function send_refund_request( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
 
@@ -791,11 +804,17 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 		);
 
 		// Craft and submit the request
-		$payload  = array(
+		$payload = array(
 			'METHOD'        => 'RefundTransaction',
 			'TRANSACTIONID' => $result['transaction_id'],
-			'REFUNDTYPE'    => 'Full',
+			'REFUNDTYPE'    => ( $refund_amount > 0 ) ? 'Partial' : 'Full',
 		);
+
+		if ( $refund_amount > 0 ) {
+			$payload['AMT']       = number_format( $refund_amount, 2, '.', '' );
+			$payload['CURRENCYCODE'] = $camptix->get_options()['currency'];
+		}
+
 		$response = $this->request( $payload );
 
 		// Process PayPal's response

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -554,15 +554,17 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	/**
 	 * Submits a single, user-initiated refund request to Stripe and returns the result.
 	 *
-	 * @param string $payment_token
+	 * @param string    $payment_token
+	 * @param float|int $refund_amount Optional. The amount to refund in the base currency unit (e.g. dollars).
+	 *                                 If 0 or not provided, a full refund is issued.
 	 *
 	 * @return int One of the CampTix_Plugin::PAYMENT_STATUS_{status} constants
 	 */
-	public function payment_refund( $payment_token ) {
+	public function payment_refund( $payment_token, $refund_amount = 0 ) {
 		/** @var CampTix_Plugin $camptix */
 		global $camptix;
 
-		$result = $this->send_refund_request( $payment_token );
+		$result = $this->send_refund_request( $payment_token, $refund_amount );
 
 		if ( CampTix_Plugin::PAYMENT_STATUS_REFUND_FAILED === $result['status'] ) {
 			$order = $this->get_order( $payment_token );
@@ -576,17 +578,28 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			);
 		}
 
+		// For partial refunds, store result data so the caller can use it
+		// without payment_result marking all attendees as refunded.
+		if ( $refund_amount > 0 ) {
+			$camptix->tmp( 'refund_transaction_id', $result['refund_transaction_id'] );
+			$camptix->tmp( 'refund_transaction_details', $result['refund_transaction_details'] );
+
+			return CampTix_Plugin::PAYMENT_STATUS_REFUNDED;
+		}
+
 		return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_REFUNDED, $result );
 	}
 
 	/**
 	 * Send a request to Stripe to refund a transaction.
 	 *
-	 * @param string $payment_token
+	 * @param string    $payment_token
+	 * @param float|int $refund_amount Optional. The amount to refund in the base currency unit (e.g. dollars).
+	 *                                 If 0 or not provided, a full refund is issued.
 	 *
 	 * @return array
 	 */
-	public function send_refund_request( $payment_token ) {
+	public function send_refund_request( $payment_token, $refund_amount = 0 ) {
 		/** @var CampTix_Plugin $camptix */
 		global $camptix;
 
@@ -610,13 +623,19 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			'Refund reason' => filter_input( INPUT_POST, 'tix_refund_request_reason', FILTER_UNSAFE_RAW ),
 		);
 
+		// Convert refund amount to fractional units (e.g. cents) for partial refunds.
+		$fractional_amount = 0;
+		if ( $refund_amount > 0 ) {
+			$fractional_amount = $this->get_fractional_unit_amount( $camptix->get_options()['currency'], $refund_amount );
+		}
+
 		// Create a new Idempotency token for the refund request.
 		// The same token can't be used for both a charge and a refund.
 		$idempotency_token = md5( 'tix-idempotency-token' . $payment_token . time() . rand( 1, 9999 ) );
 		$credentials       = $this->get_api_credentials();
 
 		$stripe = new CampTix_Stripe_API_Client( $idempotency_token, $credentials['api_secret_key'] );
-		$refund = $stripe->request_refund( $transaction_id, $metadata );
+		$refund = $stripe->request_refund( $transaction_id, $metadata, $fractional_amount );
 
 		if ( is_wp_error( $refund ) ) {
 			$result['refund_transaction_details'] = array(
@@ -945,14 +964,20 @@ class CampTix_Stripe_API_Client {
 	 *
 	 * @param string $transaction_id
 	 * @param array  $metadata       Associative array of extra data to store with the transaction.
+	 * @param int    $amount         Optional. The amount to refund in fractional currency units (e.g. cents).
+	 *                               If 0 or not provided, a full refund is issued.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function request_refund( $transaction_id, $metadata = array() ) {
+	public function request_refund( $transaction_id, $metadata = array(), $amount = 0 ) {
 		$args = array(
 			'charge' => $transaction_id,
 			'reason' => 'requested_by_customer',
 		);
+
+		if ( $amount > 0 ) {
+			$args['amount'] = $amount;
+		}
 
 		if ( is_array( $metadata ) && ! empty( $metadata ) ) {
 			$args['metadata'] = $this->clean_metadata( $metadata );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6705,6 +6705,9 @@ class CampTix_Plugin {
 			}
 		}
 
+		// Determine if this is a multi-ticket order that supports partial refunds.
+		$supports_partial = count( $attendees ) > 1;
+
 		// Has a refund request been submitted?
 		$reason = '';
 		if ( current_user_can( $this->caps['manage_attendees'] ) ) {
@@ -6724,47 +6727,110 @@ class CampTix_Plugin {
 			if ( ! $check ) {
 				$this->error( __( 'You have to agree to the terms to request a refund.', 'wordcamporg' ) );
 			} else {
-				// Allow organizers to refund tickets without transactions (i.e. free tickets)
-				if ( current_user_can( $this->caps['manage_attendees'] ) && empty( $transactions ) ) {
-					$result = $this->payment_result(
-						$tix_payment_token,
-						CampTix_Plugin::PAYMENT_STATUS_REFUNDED,
-						array(
+				// Determine which attendees to refund.
+				$selected_ids = isset( $_POST['tix_refund_attendee_ids'] ) ? array_map( 'absint', (array) $_POST['tix_refund_attendee_ids'] ) : array();
+
+				// If no checkboxes submitted (single ticket order), refund all attendees.
+				if ( empty( $selected_ids ) || ! $supports_partial ) {
+					$attendees_to_refund = $attendees;
+				} else {
+					// Validate that selected IDs belong to this order.
+					$valid_ids = wp_list_pluck( $attendees, 'ID' );
+					$selected_ids = array_intersect( $selected_ids, $valid_ids );
+
+					if ( empty( $selected_ids ) ) {
+						$this->error( __( 'Please select at least one ticket to refund.', 'wordcamporg' ) );
+						$attendees_to_refund = array();
+					} else {
+						$attendees_to_refund = array_filter( $attendees, function( $a ) use ( $selected_ids ) {
+							return in_array( $a->ID, $selected_ids, true );
+						} );
+					}
+				}
+
+				$is_partial_refund = $supports_partial && count( $attendees_to_refund ) < count( $attendees );
+
+				if ( ! empty( $attendees_to_refund ) ) {
+					// Calculate the refund amount for partial refunds.
+					$refund_amount = 0;
+					if ( $is_partial_refund ) {
+						foreach ( $attendees_to_refund as $refund_attendee ) {
+							$refund_amount += (float) get_post_meta( $refund_attendee->ID, 'tix_ticket_discounted_price', true );
+						}
+					}
+
+					// Allow organizers to refund tickets without transactions (i.e. free tickets)
+					if ( current_user_can( $this->caps['manage_attendees'] ) && empty( $transactions ) ) {
+						$refund_data = array(
 							'refund_transaction_id'      => 'no-transaction',
 							'refund_transaction_details' => array(
 								'No payment transaction to refund.',
-							)
-						)
-					);
-				} else {
-					$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );
+							),
+						);
 
-					// Bail if a payment method does not exist, or doesn't support refunds.
-					if ( ! $payment_method_obj || empty( $payment_method_obj->supported_features['refund-single'] ) ) {
-						$this->error_flags['cannot_refund'] = true;
-						$this->redirect_with_error_flags();
-						die();
+						if ( $is_partial_refund ) {
+							$result = $this->process_partial_refund( $attendees_to_refund, $refund_data );
+						} else {
+							$result = $this->payment_result(
+								$tix_payment_token,
+								CampTix_Plugin::PAYMENT_STATUS_REFUNDED,
+								$refund_data
+							);
+						}
+					} else {
+						$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );
+
+						// Bail if a payment method does not exist, or doesn't support refunds.
+						if ( ! $payment_method_obj || empty( $payment_method_obj->supported_features['refund-single'] ) ) {
+							$this->error_flags['cannot_refund'] = true;
+							$this->redirect_with_error_flags();
+							die();
+						}
+
+						// Attempt to process the refund transaction.
+						if ( $is_partial_refund ) {
+							$result = $payment_method_obj->payment_refund( $transaction['payment_token'], $refund_amount );
+
+							// If the payment gateway succeeded, mark only the selected attendees as refunded.
+							if ( CampTix_Plugin::PAYMENT_STATUS_REFUNDED == $result ) {
+								$refund_transaction_id      = $this->tmp( 'refund_transaction_id' );
+								$refund_transaction_details = $this->tmp( 'refund_transaction_details' );
+
+								foreach ( $attendees_to_refund as $refund_attendee ) {
+									$refund_attendee->post_status = 'refund';
+									wp_update_post( $refund_attendee );
+									update_post_meta( $refund_attendee->ID, 'tix_refund_transaction_id', $refund_transaction_id );
+									update_post_meta( $refund_attendee->ID, 'tix_refund_transaction_details', $refund_transaction_details );
+									$this->log( sprintf( 'Partial refund: marked attendee as refunded.' ), $refund_attendee->ID, null, 'refund' );
+								}
+							}
+						} else {
+							$result = $payment_method_obj->payment_refund( $transaction['payment_token'] );
+						}
 					}
 
-					/**
-					 * @todo: Better error messaging for misconfigured payment methods
-					 */
+					$this->log( 'Individual refund request result.', $attendees[0]->ID, $result, 'refund' );
+					if ( CampTix_Plugin::PAYMENT_STATUS_REFUNDED == $result ) {
+						foreach ( $attendees_to_refund as $refund_attendee ) {
+							update_post_meta( $refund_attendee->ID, 'tix_refund_reason', $reason );
+							$this->log( 'Refund reason attached with data.', $refund_attendee->ID, $reason, 'refund' );
+						}
 
-					// Attempt to process the refund transaction
-					$result = $payment_method_obj->payment_refund( $transaction['payment_token'] );
-				}
+						if ( $is_partial_refund ) {
+							$this->info( __( 'The selected tickets have been successfully refunded.', 'wordcamporg' ) );
 
-				$this->log( 'Individual refund request result.', $attendee->ID, $result, 'refund' );
-				if ( CampTix_Plugin::PAYMENT_STATUS_REFUNDED == $result ) {
-					foreach ( $attendees as $attendee ) {
-						update_post_meta( $attendee->ID, 'tix_refund_reason', $reason );
-						$this->log( 'Refund reason attached with data.', $attendee->ID, $reason, 'refund' );
+							// Send refund notification emails for the refunded attendees.
+							// Full refunds are handled by payment_result() -> email_tickets().
+							$receipt_email = $transaction['receipt_email'] ?? $attendee_email;
+							$this->email_partial_refund( $attendees_to_refund, $receipt_email );
+						} else {
+							$this->info( __( 'Your tickets have been successfully refunded.', 'wordcamporg' ) );
+						}
+
+						return $this->form_refund_success();
+					} else {
+						$this->error( __( 'Can not refund the transaction at this time. Please try again later.', 'wordcamporg' ) );
 					}
-
-					$this->info( __( 'Your tickets have been successfully refunded.', 'wordcamporg' ) );
-					return $this->form_refund_success();
-				} else {
-					$this->error( __( 'Can not refund the transaction at this time. Please try again later.', 'wordcamporg' ) );
 				}
 			}
 		}
@@ -6792,6 +6858,29 @@ class CampTix_Plugin {
 							<td class="tix-left"><?php _e( 'Original Payment', 'wordcamporg' ); ?></td>
 							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ?? 0 ) ); ?></td>
 						</tr>
+						<?php if ( $supports_partial ) : ?>
+						<tr>
+							<td class="tix-left"><?php _e( 'Select Tickets to Refund', 'wordcamporg' ); ?></td>
+							<td class="tix-right">
+								<?php foreach ( $attendees as $attendee ) :
+									$ticket_id    = get_post_meta( $attendee->ID, 'tix_ticket_id', true );
+									$ticket_price = (float) get_post_meta( $attendee->ID, 'tix_ticket_discounted_price', true );
+								?>
+									<label>
+										<input type="checkbox" name="tix_refund_attendee_ids[]" value="<?php echo esc_attr( $attendee->ID ); ?>" checked="checked" />
+										<?php echo esc_html( sprintf(
+											'%s %s - %s (%s %s)',
+											$attendee->tix_first_name,
+											$attendee->tix_last_name,
+											$this->get_ticket_title( $ticket_id ),
+											$this->options['currency'],
+											$ticket_price
+										) ); ?>
+									</label><br />
+								<?php endforeach; ?>
+							</td>
+						</tr>
+						<?php else : ?>
 						<tr>
 							<td class="tix-left"><?php _e( 'Purchased Tickets', 'wordcamporg' ); ?></td>
 							<td class="tix-right">
@@ -6808,6 +6897,7 @@ class CampTix_Plugin {
 								<?php endforeach; ?>
 							</td>
 						</tr>
+						<?php endif; ?>
 						<tr>
 							<td class="tix-left"><?php _e( 'Refund Amount', 'wordcamporg' ); ?></td>
 							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ?? 0 ) ); ?></td>
@@ -6819,7 +6909,11 @@ class CampTix_Plugin {
 
 					</tbody>
 				</table>
+				<?php if ( $supports_partial ) : ?>
+				<p class="tix-description"><?php _e( 'Refunds can take up to several days to process. You may select individual tickets to refund, or refund all tickets in the order. Refunds can only be issued to the original payment method. You must agree to these terms before requesting a refund.', 'wordcamporg' ); ?></p>
+				<?php else : ?>
 				<p class="tix-description"><?php _e( 'Refunds can take up to several days to process. All of the tickets you purchased in the original transaction will be cancelled. We are not able to provide partial refunds and/or refunds to a different account than the original purchaser. You must agree to these terms before requesting a refund.', 'wordcamporg' ); ?></p>
+				<?php endif; ?>
 				<p class="tix-submit">
 					<label><input type="checkbox" name="tix_refund_request_confirmed" value="1"> <?php _e( 'I agree to the above terms', 'wordcamporg' ); ?></label>
 					<input type="submit" value="<?php esc_attr_e( 'Send Request', 'wordcamporg' ); ?>" />
@@ -6848,6 +6942,61 @@ class CampTix_Plugin {
 		$contents = ob_get_contents();
 		ob_end_clean();
 		return $contents;
+	}
+
+	/**
+	 * Process a partial refund for free tickets (no payment transaction).
+	 *
+	 * @param array $attendees_to_refund Array of attendee post objects to refund.
+	 * @param array $refund_data         Refund transaction data.
+	 *
+	 * @return int Payment status constant.
+	 */
+	function process_partial_refund( $attendees_to_refund, $refund_data ) {
+		foreach ( $attendees_to_refund as $attendee ) {
+			$attendee->post_status = 'refund';
+			wp_update_post( $attendee );
+			update_post_meta( $attendee->ID, 'tix_refund_transaction_id', $refund_data['refund_transaction_id'] );
+			update_post_meta( $attendee->ID, 'tix_refund_transaction_details', $refund_data['refund_transaction_details'] );
+			$this->log( 'Partial refund: marked attendee as refunded.', $attendee->ID, $refund_data, 'refund' );
+		}
+
+		return self::PAYMENT_STATUS_REFUNDED;
+	}
+
+	/**
+	 * Send refund notification emails for partially refunded attendees.
+	 *
+	 * @param array  $refunded_attendees Array of attendee post objects that were refunded.
+	 * @param string $receipt_email      The receipt email address for the order.
+	 */
+	function email_partial_refund( $refunded_attendees, $receipt_email ) {
+		$this->remove_shortcodes();
+		$this->tmp( 'ticket_url', $this->get_tickets_url() );
+
+		foreach ( $refunded_attendees as $attendee ) {
+			$attendee_email = $this->get_attendee_email( $attendee->ID );
+
+			if ( $attendee_email && $attendee_email !== $receipt_email ) {
+				$subject        = sprintf( __( "Your Refund for %s", 'wordcamporg' ), $this->options['event_name'] );
+				$email_template = apply_filters( 'camptix_email_tickets_template', 'email_template_multiple_refund', $attendee );
+				$content        = do_shortcode( $this->options[ $email_template ] );
+
+				$this->log( sprintf( 'Sending partial refund e-mail notification to %s.', $attendee_email ), $attendee->ID );
+				$this->wp_mail( $attendee_email, $subject, $content );
+			}
+		}
+
+		// Send the receipt email to the purchaser.
+		$subject        = sprintf( __( "Your Refund for %s", 'wordcamporg' ), $this->options['event_name'] );
+		$email_template = apply_filters( 'camptix_email_tickets_template', 'email_template_single_refund', $refunded_attendees[0] );
+		$content        = do_shortcode( $this->options[ $email_template ] );
+
+		$this->log( sprintf( 'Sending partial refund e-mail notification to %s.', $receipt_email ), $refunded_attendees[0]->ID );
+		$this->wp_mail( $receipt_email, $subject, $content );
+
+		$this->tmp( 'ticket_url', false );
+		$this->restore_shortcodes();
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -219,11 +219,13 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	/**
 	 * Handle the refund process
 	 *
-	 * @param string $payment_token
+	 * @param string    $payment_token
+	 * @param float|int $refund_amount Optional. The amount to refund in the base currency unit (e.g. dollars).
+	 *                                 If 0 or not provided, a full refund is issued.
 	 *
 	 * @return int A payment status, e.g., PAYMENT_STATUS_CANCELLED, PAYMENT_STATUS_COMPLETED, etc
 	 */
-	function payment_refund( $payment_token ) {
+	function payment_refund( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix Camptix_Plugin  */
 		global $camptix;
 

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -225,7 +225,7 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	 *
 	 * @return int A payment status, e.g., PAYMENT_STATUS_CANCELLED, PAYMENT_STATUS_COMPLETED, etc
 	 */
-	function payment_refund( $payment_token, $refund_amount = 0 ) {
+	public function payment_refund( $payment_token, $refund_amount = 0 ) {
 		/** @var $camptix Camptix_Plugin  */
 		global $camptix;
 


### PR DESCRIPTION
## Summary

- When multiple tickets are purchased in a single order, the refund form now shows checkboxes to select which tickets to refund instead of requiring all tickets to be refunded together
- Adds partial refund amount support to Stripe (via `amount` parameter) and PayPal (via `REFUNDTYPE=Partial` and `AMT`) payment gateways
- Only selected attendees are marked as refunded; remaining tickets stay active
- Single-ticket orders continue to work exactly as before

Fixes WordPress/wordcamp.org#1553

## How it works

1. The refund request form detects multi-ticket orders (`count($attendees) > 1`)
2. For multi-ticket orders, checkboxes are shown next to each attendee with their ticket type and price
3. On submit, the refund amount is calculated from the selected attendees `tix_ticket_discounted_price` values
4. For partial refunds, the amount is passed to the payment gateway API instead of issuing a full refund
5. Only selected attendees are set to `refund` status; others remain published

## Test plan

- [ ] Purchase a single ticket and verify the refund form works as before (no checkboxes, full refund)
- [ ] Purchase multiple tickets in one order and verify checkboxes appear on the refund form
- [ ] Select a subset of tickets and verify only those are refunded (attendee status changes to refund)
- [ ] Verify the remaining tickets in the order stay active (status stays published)
- [ ] Select all tickets in a multi-ticket order and verify a full refund is processed
- [ ] Test with free tickets (organizer refund without payment transaction)
- [ ] Verify refund notification emails are sent correctly for partial refunds


Generated with [Claude Code](https://claude.com/claude-code)