### PR TITLE
Docker: increase upload_max_filesize to 64M

### DIFF
--- a/.docker/Dockerfile.php-fpm
+++ b/.docker/Dockerfile.php-fpm
@@ -35,6 +35,7 @@ RUN docker-php-ext-install -j "$(nproc)" \
 # Add PHP configurations.
 COPY config/opcache-recommended.ini /usr/local/etc/php/conf.d/opcache-recommended.ini
 COPY config/error-logging.ini /usr/local/etc/php/conf.d/error-logging.ini
+COPY config/uploads.ini /usr/local/etc/php/conf.d/uploads.ini
 
 # Install SSL certificate.
 COPY wordcamp.test.pem     /etc/ssl/certs/wordcamp.test.pem

--- a/.docker/config/uploads.ini
+++ b/.docker/config/uploads.ini
@@ -1,0 +1,2 @@
+upload_max_filesize = 64M
+post_max_size = 64M


### PR DESCRIPTION
## Summary
- Adds uploads.ini with upload_max_filesize = 64M and post_max_size = 64M
- Copies the config into the PHP-FPM container via Dockerfile

The default 2M PHP upload limit prevents uploading images in the local dev environment.

## Test plan
- [ ] Rebuild Docker: docker compose build
- [ ] Verify: docker compose exec wordcamp.test php -i | grep upload_max shows 64M
- [ ] Upload an image larger than 2M in wp-admin